### PR TITLE
Simplify font registration, fix splice skipping directories.

### DIFF
--- a/lib/mapnik.js
+++ b/lib/mapnik.js
@@ -70,16 +70,9 @@ exports.register_system_fonts = function() {
 
     // TODO mysys and cygwin
 
-    var found = [];
-    for (var idx in dirs) {
-        var p = dirs[idx];
-        if (path.existsSync(p)) {
-                if (mapnik.register_fonts(p, {recurse: true}))
-                    found.push(p);
-        } else {
-            dirs.splice(dirs.indexOf(p), 1);
-        }
-    }
+    var found = dirs.filter(function(p) {
+        return path.existsSync(p) && mapnik.register_fonts(p, {recurse: true});
+    });
 
     if (mapnik.fonts().length == num_faces) {
        return false;


### PR DESCRIPTION
Remove `dirs.splice` which can skip a path if a path prior to it does not exist. Example:

```
var foo = ['a', 'b', 'c'];
for (var idx in foo) {
    console.warn(foo[idx]);
    if (foo[idx] === 'b') foo.splice(foo.indexOf('b'), 1);
}
> a
> b
```

Guessing this splice is here from the early days of `node-mapnik` and just never got removed. In my particular case it was preventing `~/.fonts` from being registered because `/usr/local/share/fonts/truetype` does not exist on my system.
