### PR TITLE
Don't notify an increase in memory when objects are removed

### DIFF
--- a/src/mapnik_grid.cpp
+++ b/src/mapnik_grid.cpp
@@ -62,7 +62,8 @@ Grid::Grid(grid_ptr this_) :
 
 Grid::~Grid()
 {
-    V8::AdjustAmountOfExternalAllocatedMemory(-4 * this_->width() * this_->height());
+    // See https://github.com/mapnik/node-mapnik/issues/116 for the int cast
+    V8::AdjustAmountOfExternalAllocatedMemory(int(-4 * this_->width() * this_->height()));
 }
 
 Handle<Value> Grid::New(const Arguments& args)

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -72,7 +72,8 @@ Image::Image(image_ptr this_) :
 
 Image::~Image()
 {
-    V8::AdjustAmountOfExternalAllocatedMemory(-4 * this_->width() * this_->height());
+    // See https://github.com/mapnik/node-mapnik/issues/116 for the int cast
+    V8::AdjustAmountOfExternalAllocatedMemory(int(-4 * this_->width() * this_->height()));
 }
 
 Handle<Value> Image::New(const Arguments& args)

--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -117,8 +117,10 @@ Map::Map(int width, int height, std::string const& srs) :
 
 Map::~Map()
 {
-    if (estimated_size_ >0)
-        V8::AdjustAmountOfExternalAllocatedMemory(-estimated_size_);
+    if (estimated_size_ >0) {
+        // See https://github.com/mapnik/node-mapnik/issues/116 for the int cast
+        V8::AdjustAmountOfExternalAllocatedMemory(int(-estimated_size_));
+    }
 }
 
 void Map::acquire() {


### PR DESCRIPTION
Affects ~Image, ~Grid and ~Map. Closes #116
