### PR TITLE
Fix for gyp build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -25,7 +25,7 @@
               ],
               'AdditionalLibraryDirectories': [
                  #http://stackoverflow.com/questions/757418/should-i-compile-with-md-or-mt
-				 '<!@(mapnik-config --dep-libpaths)'
+				 '<!@(mapnik-config --dep-libs)'
               ],
             },
           }


### PR DESCRIPTION
`--dep-libpaths` was specified but I can't find any reference to it in the mapnik source; as far as I can tell `--dep-libs` is the correct option
