### PR TITLE
Update minimum protobuf version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For more sample code see https://github.com/mapnik/node-mapnik-sample-code
 
 * Node >= v0.6
 * Mapnik >= v2.2.x
-* Protobuf (protoc and libprotobuf-lite)
+* Protobuf >= 2.3.0 (protoc and libprotobuf-lite)
 
 ## Installation
 


### PR DESCRIPTION
This compile issue https://code.google.com/p/protobuf/issues/detail?id=121 seems to affect node-mapnik trunk under GCC 4.4.3/linux, with errors like

```
/usr/include/google/protobuf/repeated_field.h: In member function ‘void google::protobuf::internal::RepeatedPtrFieldBase::SwapElements(int, int)’:
/usr/include/google/protobuf/repeated_field.h:630: error: no matching function for call to ‘swap(void*&, void*&)’
```
