### PR TITLE
Auto-register fonts in MAPNIK_FONT_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## vNext
+ - Auto-registers fonts found in paths via the `MAPNIK_FONT_PATH` environment
+   variable
+
 ## 1.4.6
  - vtile.parse no longer throws if `vtile` was previously composited but no new data resulted.
  - Fixed compile problem on some linux/bsd systems

--- a/lib/mapnik.js
+++ b/lib/mapnik.js
@@ -4,6 +4,8 @@ var binding_path = path.join(__dirname,'../',pkg.binary.module_path);
 var settings_path = path.join(binding_path,'mapnik_settings.js');
 var settings = require(settings_path);
 
+var separator = (process.platform === 'win32') ? ';' : ':';
+
 // set custom env settings before loading mapnik
 if (settings.env) {
     var process_keys = Object.keys(process.env);
@@ -12,7 +14,6 @@ if (settings.env) {
             process.env[key] = settings.env[key];
         } else {
             if (key === 'PATH') {
-                var separator = (process.platform === 'win32') ? ';' : ':';
                 process.env[key] = settings.env[key] + separator + process.env[key];
             }
         }
@@ -74,3 +75,11 @@ exports.register_system_fonts = function() {
     }
 };
 
+// register paths from MAPNIK_FONT_PATH
+if (process.env.MAPNIK_FONT_PATH) {
+    process.env.MAPNIK_FONT_PATH.split(separator).forEach(function(p) {
+        if (exists(p)) {
+            mapnik.register_fonts(p);
+        }
+    });
+}

--- a/test/font_path.test.js
+++ b/test/font_path.test.js
@@ -1,0 +1,16 @@
+var assert = require('assert');
+var path = require('path');
+
+var separator = (process.platform === 'win32') ? ';' : ':';
+
+describe('mapnik fonts ', function() {
+    it('should auto-register paths in MAPNIK_FONT_PATH', function() {
+        process.env.MAPNIK_FONT_PATH = [path.join(__dirname, 'data', 'dir-区县级行政区划'),
+                                        '/System/Library/Fonts/']
+                                         .join(separator);
+
+        var mapnik = require('../');
+
+        assert.ok(mapnik.fonts().indexOf('DejaVu Sans Mono Bold Oblique') >= 0);
+    });
+});


### PR DESCRIPTION
`MAPNIK_FONT_PATH` can be set in the environment to instruct Mapnik to load fonts from a non-system, non-stylesheet-specified location.

/cc @springmeyer
