### PR TITLE
Don't rely on process.env.hasOwnProperty

### DIFF
--- a/lib/mapnik.js
+++ b/lib/mapnik.js
@@ -53,11 +53,11 @@ exports.register_system_fonts = function() {
        (process.platform.indexOf('bsd') != -1)) {
         dirs.push('/usr/share/fonts/');
         dirs.push('/usr/local/share/fonts/');
-        if (process.env.hasOwnProperty('HOME')) dirs.push(path.join(process.env.HOME, '.fonts'));
+        if (process.env.HOME) dirs.push(path.join(process.env.HOME, '.fonts'));
     } else if (process.platform === 'darwin') {
         dirs.push('/Library/Fonts');
         dirs.push('/System/Library/Fonts');
-        if (process.env.hasOwnProperty('HOME')) dirs.push(path.join(process.env.HOME, 'Library/Fonts'));
+        if (process.env.HOME) dirs.push(path.join(process.env.HOME, 'Library/Fonts'));
     } else if (process.platform === 'win32') {
        dirs.push('C:\\Windows\\Fonts');
     }


### PR DESCRIPTION
Don't rely on process.env.hasOwnProperty as in Node <0.9.0 versions it doesn't work like a proper JS object.

```
$ node -v
v0.8.28
$ node
> typeof process.env
'object'
> typeof process.env.hasOwnProperty
'undefined'
```

See: https://github.com/joyent/node/issues/3521
