### PR TITLE
3.x: Use ~ for pre-gyp semver.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies"  : {
       "nan": "~1.2.0",
       "mapnik-vector-tile": "0.5.6",
-      "node-pre-gyp": "0.5.25"
+      "node-pre-gyp": "~0.5.25"
   },
   "bundledDependencies": [
       "mapnik-vector-tile",


### PR DESCRIPTION
Main motivation: allow downstream installs to `npm dedupe` effectively post-install.

https://github.com/mapbox/mapbox-studio/issues/611#issuecomment-57152761

cc @springmeyer 
