### PR TITLE
optimize vtile.composite

### DIFF
--- a/test/vector-tile.composite.test.js
+++ b/test/vector-tile.composite.test.js
@@ -171,7 +171,7 @@ describe('mapnik.VectorTile.composite', function() {
         var vtiles = [get_tile_at('lines',[0,0,0]),get_tile_at('points',[1,1,1])]
         // raw length of input buffers
         var original_length = Buffer.concat([vtiles[0].getData(),vtiles[1].getData()]).length;
-        vtile.composite(vtiles);
+        vtile.composite(vtiles,{buffer_size:1});
         var new_length = vtile.getData().length;
         // re-rendered data should be different length
         assert.notEqual(new_length,original_length);


### PR DESCRIPTION
/cc @yhahn - 256 for a buffer size is way to aggressive of a default for compositing. I think it is better to have the defaults lower here so that we prioritize performance. This may lead to a few more clipped labels: I think the proper solution to be able to keep an adequate buffer-size would be to be able to know, per layer, what original buffer-size was used. This idea is tracked in https://github.com/mapbox/mapnik-vector-tile/issues/34.
