### PR TITLE
jshint specific files

### DIFF
--- a/bin/mapnik-shapeindex.js
+++ b/bin/mapnik-shapeindex.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+'use strict';
+
 var binary = require('node-pre-gyp'),
     path = require('path'),
     bindingPath = binary.find(path.resolve(__dirname, '..', 'package.json')),

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "engineStrict": true,
   "scripts"       : {
       "prepublish" : "npm ls",
-      "test"    : "mocha -R spec --timeout 50000",
+      "test"    : "jshint bin lib/index.js lib/mapnik.js && mocha -R spec --timeout 50000",
       "install": "node-pre-gyp install --fallback-to-build"
   },
   "devDependencies": {


### PR DESCRIPTION
jshint doesn't do its own globbing, so when you run it on windows you have to specify folders, or else specific files.