### PR TITLE
Vertex adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies"  : {
       "nan": "~1.4.0",
-      "mapnik-vector-tile": "~0.6.2",
+      "mapnik-vector-tile": "https://github.com/mapbox/mapnik-vector-tile/tarball/vertex_adapter",
       "node-pre-gyp": "~0.6.1"
   },
   "bundledDependencies": [

--- a/src/json_proj_transform_grammar.cpp
+++ b/src/json_proj_transform_grammar.cpp
@@ -2,5 +2,27 @@
 #include "proj_transform_adapter.hpp"
 #include <string>
 
+namespace mapnik { namespace json { namespace detail {
+
+// adapt mapnik::vertex_adapter get_first
+template <>
+struct get_first<node_mapnik::proj_transform_path_type>
+{
+    using geometry_type = node_mapnik::proj_transform_path_type;
+    using result_type = typename geometry_type::value_type;
+    result_type operator() (geometry_type const& geom) const
+    {
+        result_type coord;
+        geom.rewind(0);
+        std::get<0>(coord) = geom.vertex(&std::get<1>(coord),&std::get<2>(coord));
+        return coord;
+    }
+};
+
+
+} // namespace detail
+} // namespace json
+} // namespace mapnik
+
 using sink_type = std::back_insert_iterator<std::string>;
 template struct mapnik::json::multi_geometry_generator_grammar<sink_type, node_mapnik::proj_transform_container>;

--- a/src/mapnik_geometry.cpp
+++ b/src/mapnik_geometry.cpp
@@ -111,9 +111,10 @@ Local<Value> Geometry::_toJSONSync(_NAN_METHOD_ARGS) {
             ProjTransform* tr = node::ObjectWrap::Unwrap<ProjTransform>(obj);
             mapnik::proj_transform const& prj_trans = *tr->get();
             node_mapnik::proj_transform_container projected_paths;
-            for (auto & geom : g->feat_->paths())
+            for (auto const& geom : g->feat_->paths())
             {
-                projected_paths.push_back(new node_mapnik::proj_transform_path_type(geom,prj_trans));
+                mapnik::vertex_adapter va(geom);
+                projected_paths.push_back(new node_mapnik::proj_transform_path_type(va,prj_trans));
             }
             using sink_type = std::back_insert_iterator<std::string>;
             static const mapnik::json::multi_geometry_generator_grammar<sink_type,node_mapnik::proj_transform_container> proj_grammar;
@@ -189,9 +190,10 @@ void Geometry::to_json(uv_work_t* req)
         {
             mapnik::proj_transform const& prj_trans = *closure->tr->get();
             node_mapnik::proj_transform_container projected_paths;
-            for (auto & geom : closure->g->feat_->paths())
+            for (auto const& geom : closure->g->feat_->paths())
             {
-                projected_paths.push_back(new node_mapnik::proj_transform_path_type(geom,prj_trans));
+                mapnik::vertex_adapter va(geom);
+                projected_paths.push_back(new node_mapnik::proj_transform_path_type(va,prj_trans));
             }
             using sink_type = std::back_insert_iterator<std::string>;
             static const mapnik::json::multi_geometry_generator_grammar<sink_type,node_mapnik::proj_transform_container> proj_grammar;

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -465,8 +465,8 @@ NAN_METHOD(VectorTile::composite)
         VectorTile* target_vt = node::ObjectWrap::Unwrap<VectorTile>(args.Holder());
         vector_tile::Tile new_tiledata;
         vector_tile::Tile new_tiledata2;
-        for (unsigned i=0;i < num_tiles;++i) {
-            Local<Value> val = vtiles->Get(i);
+        for (unsigned j=0;j < num_tiles;++j) {
+            Local<Value> val = vtiles->Get(j);
             if (!val->IsObject()) {
                 NanThrowTypeError("must provide an array of VectorTile objects");
                 NanReturnUndefined();
@@ -899,16 +899,16 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                     for (mapnik::geometry_type const& geom : feature->paths())
                     {
                         mapnik::vertex_adapter va(geom);
-                        double d = path_to_point_distance(va,x,y);
-                        if (d >= 0)
+                        double dist = path_to_point_distance(va,x,y);
+                        if (dist >= 0)
                         {
                             if (distance >= 0)
                             {
-                                if (d < distance) distance = d;
+                                if (dist < distance) distance = dist;
                             }
                             else
                             {
-                                distance = d;
+                                distance = dist;
                             }
                         }
                     }
@@ -947,16 +947,16 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                     for (mapnik::geometry_type const& geom : feature->paths())
                     {
                         mapnik::vertex_adapter va(geom);
-                        double d = path_to_point_distance(va,x,y);
-                        if (d >= 0)
+                        double dist = path_to_point_distance(va,x,y);
+                        if (dist >= 0)
                         {
                             if (distance >= 0)
                             {
-                                if (d < distance) distance = d;
+                                if (dist < distance) distance = dist;
                             }
                             else
                             {
-                                distance = d;
+                                distance = dist;
                             }
                         }
                     }

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -1485,9 +1485,10 @@ static bool layer_to_geojson(vector_tile::Tile_Layer const& layer,
                 std::string geometry;
                 sink_type sink(geometry);
                 node_mapnik::proj_transform_container projected_paths;
-                for (auto & geom : feature->paths())
+                for (auto const& geom : feature->paths())
                 {
-                    projected_paths.push_back(new node_mapnik::proj_transform_path_type(geom,prj_trans));
+                    mapnik::vertex_adapter va(geom);
+                    projected_paths.push_back(new node_mapnik::proj_transform_path_type(va,prj_trans));
                 }
                 if (boost::spirit::karma::generate(sink, proj_grammar, projected_paths))
                 {

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -898,7 +898,8 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                     double distance = -1;
                     for (mapnik::geometry_type const& geom : feature->paths())
                     {
-                        double d = path_to_point_distance(geom,x,y);
+                        mapnik::vertex_adapter va(geom);
+                        double d = path_to_point_distance(va,x,y);
                         if (d >= 0)
                         {
                             if (distance >= 0)
@@ -945,7 +946,8 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                     double distance = -1;
                     for (mapnik::geometry_type const& geom : feature->paths())
                     {
-                        double d = path_to_point_distance(geom,x,y);
+                        mapnik::vertex_adapter va(geom);
+                        double d = path_to_point_distance(va,x,y);
                         if (d >= 0)
                         {
                             if (distance >= 0)
@@ -1211,7 +1213,8 @@ queryMany_result VectorTile::_queryMany(VectorTile* d, std::vector<query_lonlat>
                 double distance = -1;
                 for (mapnik::geometry_type const& geom : feature->paths())
                 {
-                    double d = path_to_point_distance(geom,pt.x,pt.y);
+                    mapnik::vertex_adapter va(geom);
+                    double d = path_to_point_distance(va,pt.x,pt.y);
                     if (d >= 0)
                     {
                         if (distance >= 0)

--- a/src/proj_transform_adapter.hpp
+++ b/src/proj_transform_adapter.hpp
@@ -68,7 +68,7 @@ private:
 }
 
 namespace node_mapnik {
-    using proj_transform_path_type = mapnik::proj_transform_adapter<mapnik::geometry_type>;
+    using proj_transform_path_type = mapnik::proj_transform_adapter<mapnik::vertex_adapter>;
     using proj_transform_container = boost::ptr_vector<proj_transform_path_type>;
 }
 


### PR DESCRIPTION
Adapt to advances upstream in Mapnik which allow geometries to be immutable (https://github.com/mapnik/mapnik/pull/2688) and safer to share across threads.