### PR TITLE
Expose datasource fields directly

### DIFF
--- a/src/ds_emitter.hpp
+++ b/src/ds_emitter.hpp
@@ -19,6 +19,31 @@ using namespace v8;
 
 namespace node_mapnik {
 
+static void get_fields(Local<Object> fields, mapnik::datasource_ptr ds)
+{
+        mapnik::layer_descriptor ld = ds->get_descriptor();
+        // field names and types
+        std::vector<mapnik::attribute_descriptor> const& desc = ld.get_descriptors();
+        std::vector<mapnik::attribute_descriptor>::const_iterator itr = desc.begin();
+        std::vector<mapnik::attribute_descriptor>::const_iterator end = desc.end();
+        while (itr != end)
+        {
+            unsigned field_type = itr->get_type();
+            std::string type("");
+            if (field_type == mapnik::Integer) type = "Number";
+            else if (field_type == mapnik::Float) type = "Number";
+            else if (field_type == mapnik::Double) type = "Number";
+            else if (field_type == mapnik::String) type = "String";
+            else if (field_type == mapnik::Boolean) type = "Boolean";
+            else if (field_type == mapnik::Geometry) type = "Geometry";
+            else if (field_type == mapnik::Object) type = "Object";
+            else type = "Unknown";
+            fields->Set(NanNew(itr->get_name().c_str()), NanNew(type.c_str()));
+            fields->Set(NanNew(itr->get_name().c_str()), NanNew(type.c_str()));
+            ++itr;
+        }
+}
+
 static void describe_datasource(Local<Object> description, mapnik::datasource_ptr ds)
 {
     NanScope();
@@ -41,25 +66,7 @@ static void describe_datasource(Local<Object> description, mapnik::datasource_pt
 
         // field names and types
         Local<Object> fields = NanNew<Object>();
-        std::vector<mapnik::attribute_descriptor> const& desc = ld.get_descriptors();
-        std::vector<mapnik::attribute_descriptor>::const_iterator itr = desc.begin();
-        std::vector<mapnik::attribute_descriptor>::const_iterator end = desc.end();
-        while (itr != end)
-        {
-            unsigned field_type = itr->get_type();
-            std::string type("");
-            if (field_type == mapnik::Integer) type = "Number";
-            else if (field_type == mapnik::Float) type = "Number";
-            else if (field_type == mapnik::Double) type = "Number";
-            else if (field_type == mapnik::String) type = "String";
-            else if (field_type == mapnik::Boolean) type = "Boolean";
-            else if (field_type == mapnik::Geometry) type = "Geometry";
-            else if (field_type == mapnik::Object) type = "Object";
-            else type = "Unknown";
-            fields->Set(NanNew(itr->get_name().c_str()), NanNew(type.c_str()));
-            fields->Set(NanNew(itr->get_name().c_str()), NanNew(type.c_str()));
-            ++itr;
-        }
+        node_mapnik::get_fields(fields, ds);
         description->Set(NanNew("fields"), fields);
 
         Local<String> js_type = NanNew<String>("unknown");

--- a/src/ds_emitter.hpp
+++ b/src/ds_emitter.hpp
@@ -21,27 +21,28 @@ namespace node_mapnik {
 
 static void get_fields(Local<Object> fields, mapnik::datasource_ptr ds)
 {
-        mapnik::layer_descriptor ld = ds->get_descriptor();
-        // field names and types
-        std::vector<mapnik::attribute_descriptor> const& desc = ld.get_descriptors();
-        std::vector<mapnik::attribute_descriptor>::const_iterator itr = desc.begin();
-        std::vector<mapnik::attribute_descriptor>::const_iterator end = desc.end();
-        while (itr != end)
-        {
-            unsigned field_type = itr->get_type();
-            std::string type("");
-            if (field_type == mapnik::Integer) type = "Number";
-            else if (field_type == mapnik::Float) type = "Number";
-            else if (field_type == mapnik::Double) type = "Number";
-            else if (field_type == mapnik::String) type = "String";
-            else if (field_type == mapnik::Boolean) type = "Boolean";
-            else if (field_type == mapnik::Geometry) type = "Geometry";
-            else if (field_type == mapnik::Object) type = "Object";
-            else type = "Unknown";
-            fields->Set(NanNew(itr->get_name().c_str()), NanNew(type.c_str()));
-            fields->Set(NanNew(itr->get_name().c_str()), NanNew(type.c_str()));
-            ++itr;
-        }
+    NanScope();
+    mapnik::layer_descriptor ld = ds->get_descriptor();
+    // field names and types
+    std::vector<mapnik::attribute_descriptor> const& desc = ld.get_descriptors();
+    std::vector<mapnik::attribute_descriptor>::const_iterator itr = desc.begin();
+    std::vector<mapnik::attribute_descriptor>::const_iterator end = desc.end();
+    while (itr != end)
+    {
+        unsigned field_type = itr->get_type();
+        std::string type("");
+        if (field_type == mapnik::Integer) type = "Number";
+        else if (field_type == mapnik::Float) type = "Number";
+        else if (field_type == mapnik::Double) type = "Number";
+        else if (field_type == mapnik::String) type = "String";
+        else if (field_type == mapnik::Boolean) type = "Boolean";
+        else if (field_type == mapnik::Geometry) type = "Geometry";
+        else if (field_type == mapnik::Object) type = "Object";
+        else type = "Unknown";
+        fields->Set(NanNew(itr->get_name().c_str()), NanNew(type.c_str()));
+        fields->Set(NanNew(itr->get_name().c_str()), NanNew(type.c_str()));
+        ++itr;
+    }
 }
 
 static void describe_datasource(Local<Object> description, mapnik::datasource_ptr ds)

--- a/src/mapnik_datasource.cpp
+++ b/src/mapnik_datasource.cpp
@@ -32,6 +32,7 @@ void Datasource::Initialize(Handle<Object> target) {
     NODE_SET_PROTOTYPE_METHOD(lcons, "describe", describe);
     NODE_SET_PROTOTYPE_METHOD(lcons, "featureset", featureset);
     NODE_SET_PROTOTYPE_METHOD(lcons, "extent", extent);
+    NODE_SET_PROTOTYPE_METHOD(lcons, "fields", fields);
 
     target->Set(NanNew("Datasource"), lcons->GetFunction());
     NanAssignPersistent(constructor, lcons);
@@ -229,4 +230,22 @@ NAN_METHOD(Datasource::featureset)
     }
 
     NanReturnUndefined();
+}
+
+NAN_METHOD(Datasource::fields)
+{
+    NanScope();
+    Datasource* d = node::ObjectWrap::Unwrap<Datasource>(args.Holder());
+    Local<Object> fields = NanNew<Object>();
+    try
+    {
+        node_mapnik::get_fields(fields,d->datasource_);
+    }
+    catch (std::exception const& ex)
+    {
+        NanThrowError(ex.what());
+        NanReturnUndefined();
+    }
+
+    NanReturnValue(fields);
 }

--- a/src/mapnik_datasource.hpp
+++ b/src/mapnik_datasource.hpp
@@ -25,6 +25,7 @@ public:
     static NAN_METHOD(describe);
     static NAN_METHOD(featureset);
     static NAN_METHOD(extent);
+    static NAN_METHOD(fields);
 
     Datasource();
     inline datasource_ptr get() { return datasource_; }

--- a/src/mapnik_memory_datasource.cpp
+++ b/src/mapnik_memory_datasource.cpp
@@ -28,6 +28,7 @@ void MemoryDatasource::Initialize(Handle<Object> target) {
     NODE_SET_PROTOTYPE_METHOD(lcons, "describe", describe);
     NODE_SET_PROTOTYPE_METHOD(lcons, "featureset", featureset);
     NODE_SET_PROTOTYPE_METHOD(lcons, "add", add);
+    NODE_SET_PROTOTYPE_METHOD(lcons, "fields", fields);
 
     target->Set(NanNew("MemoryDatasource"), lcons->GetFunction());
     NanAssignPersistent(constructor, lcons);
@@ -256,4 +257,22 @@ NAN_METHOD(MemoryDatasource::add)
         }
     }
     NanReturnValue(NanFalse());
+}
+
+NAN_METHOD(MemoryDatasource::fields)
+{
+    NanScope();
+    MemoryDatasource* d = node::ObjectWrap::Unwrap<MemoryDatasource>(args.Holder());
+    Local<Object> fields = NanNew<Object>();
+    if (d->datasource_) {
+        try {
+            node_mapnik::get_fields(fields,d->datasource_);
+        }
+        catch (std::exception const& ex)
+        {
+            NanThrowError(ex.what());
+            NanReturnUndefined();
+        }
+    }
+    NanReturnValue(fields);
 }

--- a/src/mapnik_memory_datasource.hpp
+++ b/src/mapnik_memory_datasource.hpp
@@ -23,6 +23,7 @@ public:
     static NAN_METHOD(features);
     static NAN_METHOD(featureset);
     static NAN_METHOD(add);
+    static NAN_METHOD(fields);
 
     MemoryDatasource();
     inline mapnik::datasource_ptr get() { return datasource_; }

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -90,6 +90,8 @@ describe('mapnik.Datasource', function() {
         assert.deepEqual(actual.geometry_type, expected.geometry_type);
 
         assert.deepEqual(ds.extent(), expected.extent);
+
+        assert.deepEqual(ds.fields(), expected.fields);
     });
     it('should validate with known shapefile', function() {
         var options = {
@@ -154,6 +156,8 @@ describe('mapnik.Datasource', function() {
         assert.deepEqual(actual.geometry_type, expected.geometry_type);
 
         assert.deepEqual(ds.extent(), expected.extent);
+
+        assert.deepEqual(ds.fields(), expected.fields);
     });
 
 


### PR DESCRIPTION
This change addresses #431, and exposes datasource fields directly via a `fields()` method.  This should allow Mapbox Studio to retrieve just the fields it needs without incurring some other potentially expensive side-effects of calling `describe()` on the datasource.