### PR TITLE
Implement gzip compression in the C++ layer

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -99,6 +99,7 @@
               'mapnik-json.lib',
               '<!@(mapnik-config --dep-libs)',
               'libprotobuf-lite.lib',
+              'zlib.lib'
             ],
             'msvs_disabled_warnings': [ 4244,4005,4506,4345,4804,4805 ],
             'msvs_settings': {
@@ -120,6 +121,7 @@
               '-lmapnik-json',
               '<!@(mapnik-config --ldflags)',
               '-lprotobuf-lite',
+              '-lz'
             ],
             'xcode_settings': {
               'OTHER_CPLUSPLUSFLAGS':[

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -2544,7 +2544,7 @@ Local<Value> VectorTile::_getData(_NAN_METHOD_ARGS)
                 if (compressed_data.size() >= node::Buffer::kMaxLength) {
                     std::ostringstream s;
                     s << "Compressed data is too large to convert to a node::Buffer ";
-                    s << "(" << raw_size << " raw bytes >= node::Buffer::kMaxLength)";
+                    s << "(" << compressed_data.size() << " compressed bytes >= node::Buffer::kMaxLength)";
                     throw std::runtime_error(s.str());
                 }
                 return NanEscapeScope(NanNewBufferHandle(compressed_data.c_str(), compressed_data.size()));
@@ -2582,8 +2582,14 @@ Local<Value> VectorTile::_getData(_NAN_METHOD_ARGS)
                 }
                 if (gzip)
                 {
-                  std::string compressed_data = _gzip_compress(start, d->byte_size_, level);
-                  return NanEscapeScope(NanNewBufferHandle(compressed_data.c_str(), compressed_data.size()));
+                    std::string compressed_data = _gzip_compress(start, d->byte_size_, level);
+                    if (compressed_data.size() >= node::Buffer::kMaxLength) {
+                        std::ostringstream s;
+                        s << "Compressed data is too large to convert to a node::Buffer ";
+                        s << "(" << compressed_data.size() << " compressed bytes >= node::Buffer::kMaxLength)";
+                        throw std::runtime_error(s.str());
+                    }
+                    return NanEscapeScope(NanNewBufferHandle(compressed_data.c_str(), compressed_data.size()));
                 }
                 return NanEscapeScope(retbuf);
             }

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -2547,7 +2547,7 @@ Local<Value> VectorTile::_getData(_NAN_METHOD_ARGS)
                     s << "(" << raw_size << " raw bytes >= node::Buffer::kMaxLength)";
                     throw std::runtime_error(s.str());
                 }
-                return NanNewBufferHandle(compressed_data.c_str(), compressed_data.size());
+                return NanEscapeScope(NanNewBufferHandle(compressed_data.c_str(), compressed_data.size()));
             }
             if (raw_size >= node::Buffer::kMaxLength) {
                 std::ostringstream s;
@@ -2555,10 +2555,10 @@ Local<Value> VectorTile::_getData(_NAN_METHOD_ARGS)
                 s << "(" << raw_size << " raw bytes >= node::Buffer::kMaxLength)";
                 throw std::runtime_error(s.str());
             }
-            return NanNewBufferHandle((char*)d->buffer_.data(),raw_size);
+            return NanEscapeScope(NanNewBufferHandle((char*)d->buffer_.data(),raw_size));
         } else {
             if (d->byte_size_ <= 0) {
-                return NanNewBufferHandle(0);
+                return NanEscapeScope(NanNewBufferHandle(0));
             } else {
                 // NOTE: tiledata.ByteSize() must be called
                 // after each modification of tiledata otherwise the
@@ -2583,9 +2583,9 @@ Local<Value> VectorTile::_getData(_NAN_METHOD_ARGS)
                 if (gzip)
                 {
                   std::string compressed_data = _gzip_compress(start, d->byte_size_, level);
-                  return NanNewBufferHandle(compressed_data.c_str(), compressed_data.size());
+                  return NanEscapeScope(NanNewBufferHandle(compressed_data.c_str(), compressed_data.size()));
                 }
-                return retbuf;
+                return NanEscapeScope(retbuf);
             }
         }
     }

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -55,6 +55,8 @@
 #include <mapnik/hit_test_filter.hpp>
 #include <google/protobuf/io/coded_stream.h>
 
+#include <zlib.h>
+
 namespace detail {
 
 struct p2p_distance
@@ -2397,24 +2399,166 @@ void VectorTile::EIO_AfterSetData(uv_work_t* req)
     delete closure;
 }
 
+#define MOD_GZIP_ZLIB_WINDOWSIZE 15
+#define MOD_GZIP_ZLIB_CFACTOR 9
+
+std::string VectorTile::_gzip_compress(const unsigned char * str, const int len,
+                                        int compressionlevel = Z_BEST_COMPRESSION,
+                                        int strategy = Z_DEFAULT_STRATEGY)
+{
+
+
+    z_stream zs;
+    memset(&zs, 0, sizeof(zs));
+
+    if (deflateInit2(&zs, compressionlevel, Z_DEFLATED,
+                      MOD_GZIP_ZLIB_WINDOWSIZE + 16,
+                      MOD_GZIP_ZLIB_CFACTOR,
+                      strategy) != Z_OK)
+        throw(std::runtime_error("deflateInit failed while compressing."));
+
+    zs.next_in = (unsigned char *)str;
+    zs.avail_in = len;
+
+    int ret;
+    char outbuffer[32768];
+    std::string outstring;
+
+    // retrieve the compressed bytes blockwise
+    do {
+        zs.next_out = reinterpret_cast<Bytef*>(outbuffer);
+        zs.avail_out = sizeof(outbuffer);
+
+        ret = deflate(&zs, Z_FINISH);
+
+        if (outstring.size() < zs.total_out) {
+            // append the block to the output string
+            outstring.append(outbuffer,
+                             zs.total_out - outstring.size());
+        }
+    } while (ret == Z_OK);
+
+    deflateEnd(&zs);
+
+    if (ret != Z_STREAM_END) {          // an error occurred that was not EOF
+        std::ostringstream oss;
+        oss << "Exception during zlib compression: (" << ret << ") " << zs.msg;
+        throw(std::runtime_error(oss.str()));
+    }
+
+    return outstring;
+}
+
+
 NAN_METHOD(VectorTile::getData)
 {
     NanScope();
+    NanReturnValue(_getData(args));
+}
+
+
+
+Local<Value> VectorTile::_getData(_NAN_METHOD_ARGS)
+{
+    NanEscapableScope();
     VectorTile* d = node::ObjectWrap::Unwrap<VectorTile>(args.Holder());
+
+    Local<Object> options = NanNew<Object>();
+    bool gzip = false;
+    int level = 9;
+    int strategy = Z_DEFAULT_STRATEGY;
+
+    if (args.Length() > 0)
+    {
+        // options object
+        if (!args[0]->IsObject())
+        {
+            throw std::runtime_error("first argument must be an options object");
+        }
+
+        options = args[0]->ToObject();
+
+        if (options->Has(NanNew("compression")))
+        {
+            Local<Value> param_val = options->Get(NanNew("compression"));
+            if (!param_val->IsString())
+            {
+                throw std::runtime_error("option 'compression' must be a string, either 'gzip', or 'none' (default)");
+            }
+            gzip = std::string("gzip") == (TOSTR(param_val->ToString()));
+        }
+
+        if (options->Has(NanNew("level")))
+        {
+            Local<Value> param_val = options->Get(NanNew("level"));
+            if (!param_val->IsNumber())
+            {
+                throw std::runtime_error("option 'level' must be an integer between 0 (no compression) and 9 (best compression) inclusive");
+            }
+            level = param_val->IntegerValue();
+            if (level < 0 || level > 9)
+            {
+                throw std::runtime_error("option 'level' must be an integer between 0 (no compression) and 9 (best compression) inclusive");
+            }
+        }
+        if (options->Has(NanNew("strategy")))
+        {
+            Local<Value> param_val = options->Get(NanNew("level"));
+            if (!param_val->IsString())
+            {
+                throw std::runtime_error("option 'strategy' must be one of the following strings: FILTERED, HUFFMAN_ONLY, RLE, FIXED, DEFAULT");
+            }
+            else if (std::string("FILTERED") == TOSTR(param_val->ToString()))
+            {
+                strategy = Z_FILTERED;
+            }
+            else if (std::string("HUFFMAN_ONLY") == TOSTR(param_val->ToString()))
+            {
+                strategy = Z_HUFFMAN_ONLY;
+            }
+            else if (std::string("RLE") == TOSTR(param_val->ToString()))
+            {
+                strategy = Z_RLE;
+            }
+            else if (std::string("FIXED") == TOSTR(param_val->ToString()))
+            {
+                strategy = Z_FIXED;
+            }
+            else if (std::string("DEFAULT") == TOSTR(param_val->ToString()))
+            {
+                strategy = Z_DEFAULT_STRATEGY;
+            }
+            else
+            {
+                throw std::runtime_error("option 'strategy' must be one of the following strings: FILTERED, HUFFMAN_ONLY, RLE, FIXED, DEFAULT");
+            }
+        }
+    }
     try {
         // shortcut: return raw data and avoid trip through proto object
         std::size_t raw_size = d->buffer_.size();
         if (raw_size > 0 && (d->byte_size_ < 0 || static_cast<std::size_t>(d->byte_size_) <= raw_size)) {
+            if (gzip)
+            {
+                std::string compressed_data = _gzip_compress((unsigned char *)d->buffer_.data(), raw_size, level);
+                if (compressed_data.size() >= node::Buffer::kMaxLength) {
+                    std::ostringstream s;
+                    s << "Compressed data is too large to convert to a node::Buffer ";
+                    s << "(" << raw_size << " raw bytes >= node::Buffer::kMaxLength)";
+                    throw std::runtime_error(s.str());
+                }
+                return NanNewBufferHandle(compressed_data.c_str(), compressed_data.size());
+            }
             if (raw_size >= node::Buffer::kMaxLength) {
                 std::ostringstream s;
                 s << "Data is too large to convert to a node::Buffer ";
                 s << "(" << raw_size << " raw bytes >= node::Buffer::kMaxLength)";
                 throw std::runtime_error(s.str());
             }
-            NanReturnValue(NanNewBufferHandle((char*)d->buffer_.data(),raw_size));
+            return NanNewBufferHandle((char*)d->buffer_.data(),raw_size);
         } else {
             if (d->byte_size_ <= 0) {
-                NanReturnValue(NanNewBufferHandle(0));
+                return NanNewBufferHandle(0);
             } else {
                 // NOTE: tiledata.ByteSize() must be called
                 // after each modification of tiledata otherwise the
@@ -2426,6 +2570,7 @@ NAN_METHOD(VectorTile::getData)
                     s << "(" << d->byte_size_ << " cached bytes >= node::Buffer::kMaxLength)";
                     throw std::runtime_error(s.str());
                 }
+                // TODO: possible memory leak here if gzip is used????
                 Local<Object> retbuf = NanNewBufferHandle(d->byte_size_);
                 // TODO - consider wrapping in fastbuffer: https://gist.github.com/drewish/2732711
                 // http://www.samcday.com.au/blog/2011/03/03/creating-a-proper-buffer-in-a-node-c-addon/
@@ -2435,14 +2580,21 @@ NAN_METHOD(VectorTile::getData)
                 if (end - start != d->byte_size_) {
                     throw std::runtime_error("serialization failed, possible race condition");
                 }
-                NanReturnValue(retbuf);
+                if (gzip)
+                {
+                  std::string compressed_data = _gzip_compress(start, d->byte_size_, level);
+                  return NanNewBufferHandle(compressed_data.c_str(), compressed_data.size());
+                }
+                return retbuf;
             }
         }
-    } catch (std::exception const& ex) {
-        NanThrowError(ex.what());
-        NanReturnUndefined();
     }
-    NanReturnUndefined();
+    catch (std::exception const& ex)
+    {
+        NanThrowError(ex.what());
+        return NanEscapeScope(NanUndefined());
+    }
+    return NanEscapeScope(NanUndefined());
 }
 
 using surface_type = mapnik::util::variant<Image *, CairoSurface *, Grid *>;

--- a/src/mapnik_vector_tile.hpp
+++ b/src/mapnik_vector_tile.hpp
@@ -44,6 +44,7 @@ public:
     static Persistent<FunctionTemplate> constructor;
     static void Initialize(Handle<Object> target);
     static NAN_METHOD(New);
+    static Local<Value> _getData(_NAN_METHOD_ARGS);
     static NAN_METHOD(getData);
     static NAN_METHOD(render);
     static NAN_METHOD(toJSON);
@@ -148,6 +149,7 @@ public:
     parsing_status status_;
 private:
     ~VectorTile();
+    static std::string _gzip_compress(const unsigned char * str, const int len, int compressionlevel, int strategy);
     vector_tile::Tile tiledata_;
     unsigned width_;
     unsigned height_;

--- a/test/vector-tile.compression.test.js
+++ b/test/vector-tile.compression.test.js
@@ -50,7 +50,11 @@ describe('mapnik.VectorTile compression', function() {
 
         assert.equal(vtile.getData().length, 58);
         assert.equal(vtile.getData({ compression: 'gzip'}).length,76);
-        assert.equal(zlib.gunzipSync(vtile.getData({ compression: 'gzip'})).length,58);
+
+        // Actually test decompressing, but only available on NodeJS >= 0.12.4
+        if (typeof zlib.gunzipSync != 'undefined') {
+            assert.equal(zlib.gunzipSync(vtile.getData({ compression: 'gzip'})).length,58);
+        }
 
         done();
     });

--- a/test/vector-tile.compression.test.js
+++ b/test/vector-tile.compression.test.js
@@ -1,0 +1,58 @@
+"use strict";
+
+var zlib = require('zlib');
+var mapnik = require('../');
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+var mercator = new(require('sphericalmercator'))();
+var existsSync = require('fs').existsSync || require('path').existsSync;
+var overwrite_expected_data = false;
+//var SegfaultHandler = require('segfault-handler');
+//SegfaultHandler.registerHandler();
+
+mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojson.input'));
+
+var trunc_6 = function(key, val) {
+    return val.toFixed ? Number(val.toFixed(6)) : val;
+};
+
+function deepEqualTrunc(json1,json2) {
+    return assert.deepEqual(JSON.stringify(json1,trunc_6),JSON.stringify(json2,trunc_6));
+}
+
+mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'shape.input'));
+mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'gdal.input'));
+
+describe('mapnik.VectorTile compression', function() {
+
+    it('should be able to create a vector tile from geojson', function(done) {
+        var vtile = new mapnik.VectorTile(0,0,0);
+        var geojson = {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "geometry": {
+                "type": "Point",
+                "coordinates": [
+                  -122,
+                  48
+                ]
+              },
+              "properties": {
+                "name": "geojson data"
+              }
+            }
+          ]
+        };
+        vtile.addGeoJSON(JSON.stringify(geojson),"layer-name");
+
+        assert.equal(vtile.getData().length, 58);
+        assert.equal(vtile.getData({ compression: 'gzip'}).length,76);
+        assert.equal(zlib.gunzipSync(vtile.getData({ compression: 'gzip'})).length,58);
+
+        done();
+    });
+
+});

--- a/test/vector-tile.compression.test.js
+++ b/test/vector-tile.compression.test.js
@@ -24,47 +24,7 @@ function deepEqualTrunc(json1,json2) {
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'shape.input'));
 mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'gdal.input'));
 
-<<<<<<< HEAD
 describe('mapnik.VectorTile compression', function() {
-=======
-describe('mapnik.VectorTile ', function() {
-    // generate test data
-    var _vtile;
-    var _data;
-    var _length;
-    before(function(done) {
-        if (overwrite_expected_data) {
-            var map = new mapnik.Map(256, 256);
-            map.loadSync('./test/data/vector_tile/layers.xml');
-            var vtile = new mapnik.VectorTile(9,112,195);
-            _vtile = vtile;
-            map.extent = [-11271098.442818949,4696291.017841229,-11192826.925854929,4774562.534805249];
-            map.render(vtile,{},function(err,vtile) {
-                if (err) throw err;
-                fs.writeFileSync('./test/data/vector_tile/tile1.vector.pbf',vtile.getData());
-                _data = vtile.getData().toString("hex");
-                _length = vtile.getData().length;
-                var map2 = new mapnik.Map(256,256);
-                map2.loadSync('./test/data/vector_tile/layers.xml');
-                var vtile2 = new mapnik.VectorTile(5,28,12);
-                var bbox = mercator.bbox(28, 12, 5, false, '900913');
-                map2.extent = bbox;
-                map2.render(vtile2,{}, function(err,vtile2) {
-                    if (err) throw err;
-                    fs.writeFileSync("./test/data/vector_tile/tile3.vector.pbf",vtile2.getData());
-                    done();
-                });
-            });
-        } else {
-            _vtile = new mapnik.VectorTile(9,112,195);
-            _vtile.setData(fs.readFileSync('./test/data/vector_tile/tile1.vector.pbf'));
-            _vtile.parse();
-            _data = _vtile.getData().toString("hex");
-            _length = _vtile.getData().length;
-            done();
-        }
-    });
->>>>>>> 4f6659bcb775664479abc13d76c692c10400df95
 
     it('should be able to create a vector tile from geojson', function(done) {
         var vtile = new mapnik.VectorTile(0,0,0);


### PR DESCRIPTION
This change goes towards #413, adding

    tile.getData({compression: 'gzip', level:9, strategy:"DEFAULT"});

options so that vtile compression can be done in the C++ layer, rather than passing full data out to NodeJS.

Points to review:
  - ~~not clear on all the return types, do they need to be wrapped in `NanEscapeScope()`?~~
  - private method `_gzip_compress`, is there a better place to put this?
  - data types passed to and returned from `_gzip_compress`, are they appropriate in C++-world?