### PR TITLE
Pt ln query [Don't Merge]

### DIFF
--- a/test/data/block.json
+++ b/test/data/block.json
@@ -1,0 +1,54 @@
+{
+    "type": "FeatureCollection",
+    "features": [{
+        "type": "Feature", "properties": { "name": "line1" },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [ [ -77.0612, 38.9068 ], [ -77.0591, 38.9068 ] ] }
+    },{
+        "type": "Feature", "properties": { "name": "line2" },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [ [ -77.0591, 38.9068 ], [ -77.0591, 38.9052 ] ] }
+    },{
+        "type": "Feature", "properties": { "name": "line3" },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [ [ -77.0591, 38.9052 ], [ -77.06117, 38.9052 ] ] }
+    },{
+        "type": "Feature", "properties": { "name": "line4" },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [ [ -77.06117, 38.9052 ], [ -77.0612, 38.9068 ] ] }
+    },{
+        "type": "Feature",
+        "properties": { "name": "point1" },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [ -77.0610, 38.9066 ] }
+    },{
+        "type": "Feature",
+        "properties": { "name": "point3" },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [ -77.0610, 38.9060 ] }
+    },{
+        "type": "Feature",
+        "properties": { "name": "point4" },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [ -77.0607, 38.9053 ] }
+    },{
+        "type": "Feature",
+        "properties": { "name": "point2" },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [ -77.0595, 38.9065 ] }
+    },{
+        "type": "Feature",
+        "properties": { "name": "point5" },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [ -77.05957263708115, 38.905622084028714 ] } }
+    ]
+}

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -527,32 +527,11 @@ describe('mapnik.VectorTile triangle query', function() {
     })
 });
 
-
-describe('mapnik.VectorTile equidistance', function() {
-    it('two features', function(done) {
-
-        var vtile = new mapnik.VectorTile(0,0,0);
-        vtile.addGeoJSON(JSON.stringify({
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": { "type": "LineString", "coordinates": [ [-180,85],[180,-85] ] },
-                    "properties": { "_text": "A" }
-                }
-            ]
-        }),"data");
-        vtile.query(170, 80, {}, function(err, data) {
-            assert.ifError(err);
-            assert.equal(data, false);
-            done()
-        })
-    })
-});
-
 describe('mapnik.VectorTile query point & line', function() {
-    it('line point', function(done) {
-        var vtile = new mapnik.VectorTile(12,1294,1468);
+    it('point near line', function(done) {
+        // --------
+        //    o
+        var vtile = new mapnik.VectorTile(0,0,0);
         vtile.addGeoJSON(JSON.stringify({
             "type": "FeatureCollection",
             "features": [{
@@ -560,7 +539,7 @@ describe('mapnik.VectorTile query point & line', function() {
                 "properties": { "name": "point" },
                 "geometry": {
                     "type": "Point",
-                    "coordinates": [ -66.19295954704285, 45.32757192213404 ]
+                    "coordinates": [ 0, 0 ]
                 }
             },{
                 "type": "Feature",
@@ -568,17 +547,93 @@ describe('mapnik.VectorTile query point & line', function() {
                 "geometry": {
                     "type": "LineString",
                     "coordinates": [
-                        [ -66.1936193704605, 45.32768695178765 ],
-                        [ -66.19305342435837, 45.32779820975496 ],
-                        [ -66.19213342666626, 45.3278132955642 ]
+                        [ -20, 10 ],
+                        [ 20, 10 ]
                     ]
                 }
         }]}),'data');
-        vtile.query(-66.19295954704285, 45.32757192213404, { tolerance: 10000 }, function(err, data) {
-            assert.equal(data.length, 2);
-            assert.equal(data[0].attributes().name, 'point')
-            assert.equal(data[1].attributes().name, 'line')
-            done();
-        });
+
+        //query on point
+        var data = vtile.query(0,0, { tolerance: 1000000 });
+        assert.equal(data.length, 1);
+        assert.equal(data[0].attributes().name, 'point')
+
+        //query on line
+        var data = vtile.query(0,10, { tolerance: 1000000 });
+        assert.equal(data.length, 1);
+        assert.equal(data[0].attributes().name, 'line')
+
+        //query between
+        var data = vtile.query(0,5, { tolerance: 1000000 });
+        assert.equal(data.length, 2);
+        assert.equal(data[0].attributes().name, 'point')
+        assert.equal(data[1].attributes().name, 'line')
+        done();
+    });
+
+    it('point on mid line', function(done) {
+        // ----o---- <= query on line
+
+        var vtile = new mapnik.VectorTile(0,0,0);
+        vtile.addGeoJSON(JSON.stringify({
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": { "name": "point" },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [ 0, 0 ]
+                }
+            },{
+                "type": "Feature",
+                "properties": { "name": "line" },
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [
+                        [ -20, 0 ],
+                        [ 20, 0 ]
+                    ]
+                }
+        }]}),'data');
+
+        //query on point
+        var data = vtile.query(0,0, { tolerance: 1 });
+        assert.equal(data.length, 2);
+        assert.equal(data[0].attributes().name, 'line')
+        assert.equal(data[1].attributes().name, 'point');
+        done();
+    });
+
+    it('point on end line', function(done) {
+        // --------o <= query on line
+
+        var vtile = new mapnik.VectorTile(0,0,0);
+        vtile.addGeoJSON(JSON.stringify({
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": { "name": "point" },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [ 20, 0 ]
+                }
+            },{
+                "type": "Feature",
+                "properties": { "name": "line" },
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [
+                        [ -20, 0 ],
+                        [ 20, 0 ]
+                    ]
+                }
+        }]}),'data');
+
+        //query on point
+        var data = vtile.query(20,0, { tolerance: 10000 });
+        assert.equal(data.length, 2);
+        assert.equal(data[0].attributes().name, 'line')
+        assert.equal(data[1].attributes().name, 'point')
+        done();
     });
 });

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -500,7 +500,7 @@ describe('mapnik.VectorTile query (distance <= tolerance)', function() {
 
 describe('mapnik.VectorTile query point & line', function() {
     it('line point', function(done) {
-        var vtile = new mapnik.VectorTile(12,750,1372);
+        var vtile = new mapnik.VectorTile(12,1294,1468);
         vtile.addGeoJSON(JSON.stringify({
             "type": "FeatureCollection",
             "features": [{
@@ -522,13 +522,9 @@ describe('mapnik.VectorTile query point & line', function() {
                     ]
                 }
         }]}),'data');
-        vtile.toGeoJSON('data',function(err, data) {
+        vtile.query(-66.19295954704285, 45.32757192213404, { tolerance: 10000 }, function(err, data) {
             console.log(data);
-            done()
+            done();
         });
-        //vtile.query(-66.19295954704285, 45.32757192213404, { tolerance: 10000 }, function(err, data) {
-        //    console.log(data);
-        //    done();
-        //});
     });
 });

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -498,3 +498,37 @@ describe('mapnik.VectorTile query (distance <= tolerance)', function() {
     });
 });
 
+describe('mapnik.VectorTile query point & line', function() {
+    it('line point', function(done) {
+        var vtile = new mapnik.VectorTile(12,750,1372);
+        vtile.addGeoJSON(JSON.stringify({
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": { "name": "point" },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [ -66.19295954704285, 45.32757192213404 ]
+                }
+            },{
+                "type": "Feature",
+                "properties": { "name": "line" },
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [
+                        [ -66.1936193704605, 45.32768695178765 ],
+                        [ -66.19305342435837, 45.32779820975496 ],
+                        [ -66.19213342666626, 45.3278132955642 ]
+                    ]
+                }
+        }]}),'data');
+        vtile.toGeoJSON('data',function(err, data) {
+            console.log(data);
+            done()
+        });
+        //vtile.query(-66.19295954704285, 45.32757192213404, { tolerance: 10000 }, function(err, data) {
+        //    console.log(data);
+        //    done();
+        //});
+    });
+});

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -522,9 +522,9 @@ describe('mapnik.VectorTile triangle query', function() {
         vtile.query(170, 80, {}, function(err, data) {
             assert.ifError(err);
             assert.equal(data, false);
-            done()
-        })
-    })
+            done();
+        });
+    });
 });
 
 describe('mapnik.VectorTile query point & line', function() {
@@ -556,24 +556,24 @@ describe('mapnik.VectorTile query point & line', function() {
         //query on point
         var data = vtile.query(0,0, { tolerance: 1000000 });
         assert.equal(data.length, 1);
-        assert.equal(data[0].attributes().name, 'point')
+        assert.equal(data[0].attributes().name, 'point');
 
         //query on line
-        var data = vtile.query(0,10, { tolerance: 1000000 });
+        data = vtile.query(0,10, { tolerance: 1000000 });
         assert.equal(data.length, 1);
-        assert.equal(data[0].attributes().name, 'line')
+        assert.equal(data[0].attributes().name, 'line');
 
         //query between
-        var data = vtile.query(0,5, { tolerance: 1000000 });
+        data = vtile.query(0,5, { tolerance: 1000000 });
         assert.equal(data.length, 2);
-        assert.equal(data[0].attributes().name, 'point')
-        assert.equal(data[1].attributes().name, 'line')
+        assert.equal(data[0].attributes().name, 'point');
+        assert.equal(data[1].attributes().name, 'line');
         done();
     });
 
     it('point on mid line', function(done) {
         // ----o---- <= query on line
-        //mapnik returns two features with identical distances
+        // mapnik returns two features with identical distances (as expected)
 
         var vtile = new mapnik.VectorTile(0,0,0);
         vtile.addGeoJSON(JSON.stringify({
@@ -601,7 +601,7 @@ describe('mapnik.VectorTile query point & line', function() {
         var data = vtile.query(0,0, { tolerance: 1 });
         assert.equal(data.length, 2);
         assert.equal(data[0].distance, data[1].distance);
-        assert.equal(data[0].attributes().name, 'point')
+        assert.equal(data[0].attributes().name, 'point');
         assert.equal(data[1].attributes().name, 'line');
         done();
     });
@@ -632,10 +632,46 @@ describe('mapnik.VectorTile query point & line', function() {
         }]}),'data');
 
         //query on point
-        var data = vtile.query(100,0, { tolerance: 10000 });
+        var data = vtile.query(100,0, { tolerance: 10000 }); //Problematic - this tolerance should be able to be much lower
         assert.equal(data.length, 2);
-        assert.equal(data[0].attributes().name, 'line')
-        assert.equal(data[1].attributes().name, 'point')
+        assert.equal(data[0].attributes().name, 'line');
+        assert.equal(data[1].attributes().name, 'point');
+        done();
+    });
+});
+
+
+describe('mapnik.VectorTile streets', function() {
+    it('block', function(done) {
+        // +--1--+
+        // | o o | pt1 pt2
+        // |     |
+        // 4 o   2 pt3
+        // |     |
+        // | o o | pt4 pt5
+        // +--3--+
+        var vtile = new mapnik.VectorTile(0,0,0);
+        vtile.addGeoJSON(JSON.stringify(require('./data/block.json')),"data");
+
+        var data = vtile.query(-77.0610,38.9066, {tolerance: 10000 });
+        assert.equal(data[0].attributes().name, 'point1');
+
+        //Point 2
+        data = vtile.query(-77.0595,38.9065, {tolerance: 1000 });
+        assert.equal(data[0].attributes().name, 'point2');
+
+        //Point 3
+        data = vtile.query(-77.0610,38.9060, {tolerance: 1000 });
+        assert.equal(data[0].attributes().name, 'point3');
+
+        //Point 4
+        data = vtile.query(-77.0607,38.9053, {tolerance: 1000 });
+        assert.equal(data[0].attributes().name, 'point4');
+
+        //Point 5
+        data = vtile.query(-77.0595,38.9056, {tolerance: 1000 });
+        assert.equal(data[0].attributes().name, 'point5');
+
         done();
     });
 });

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -498,6 +498,58 @@ describe('mapnik.VectorTile query (distance <= tolerance)', function() {
     });
 });
 
+describe('mapnik.VectorTile triangle query', function() {
+    it('triangle corner', function(done) {
+
+        // o-----x <-- query
+        // |\    |     the distance in this case is millions of miles
+        // | \   |     (24364904ish)
+        // |  \  |
+        // |   \ |
+        // |    \|
+        // +-----o
+        var vtile = new mapnik.VectorTile(0,0,0);
+        vtile.addGeoJSON(JSON.stringify({
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": { "type": "LineString", "coordinates": [ [-180,85],[180,-85] ] },
+                    "properties": { "_text": "A" }
+                }
+            ]
+        }),"data");
+        vtile.query(170, 80, {}, function(err, data) {
+            assert.ifError(err);
+            assert.equal(data, false);
+            done()
+        })
+    })
+});
+
+
+describe('mapnik.VectorTile equidistance', function() {
+    it('two features', function(done) {
+
+        var vtile = new mapnik.VectorTile(0,0,0);
+        vtile.addGeoJSON(JSON.stringify({
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": { "type": "LineString", "coordinates": [ [-180,85],[180,-85] ] },
+                    "properties": { "_text": "A" }
+                }
+            ]
+        }),"data");
+        vtile.query(170, 80, {}, function(err, data) {
+            assert.ifError(err);
+            assert.equal(data, false);
+            done()
+        })
+    })
+});
+
 describe('mapnik.VectorTile query point & line', function() {
     it('line point', function(done) {
         var vtile = new mapnik.VectorTile(12,1294,1468);
@@ -523,7 +575,9 @@ describe('mapnik.VectorTile query point & line', function() {
                 }
         }]}),'data');
         vtile.query(-66.19295954704285, 45.32757192213404, { tolerance: 10000 }, function(err, data) {
-            console.log(data);
+            assert.equal(data.length, 2);
+            assert.equal(data[0].attributes().name, 'point')
+            assert.equal(data[1].attributes().name, 'line')
             done();
         });
     });

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -573,6 +573,7 @@ describe('mapnik.VectorTile query point & line', function() {
 
     it('point on mid line', function(done) {
         // ----o---- <= query on line
+        //mapnik returns two features with identical distances
 
         var vtile = new mapnik.VectorTile(0,0,0);
         vtile.addGeoJSON(JSON.stringify({
@@ -590,8 +591,8 @@ describe('mapnik.VectorTile query point & line', function() {
                 "geometry": {
                     "type": "LineString",
                     "coordinates": [
-                        [ -20, 0 ],
-                        [ 20, 0 ]
+                        [ -100, 0 ],
+                        [ 100, 0 ]
                     ]
                 }
         }]}),'data');
@@ -599,8 +600,9 @@ describe('mapnik.VectorTile query point & line', function() {
         //query on point
         var data = vtile.query(0,0, { tolerance: 1 });
         assert.equal(data.length, 2);
-        assert.equal(data[0].attributes().name, 'line')
-        assert.equal(data[1].attributes().name, 'point');
+        assert.equal(data[0].distance, data[1].distance);
+        assert.equal(data[0].attributes().name, 'point')
+        assert.equal(data[1].attributes().name, 'line');
         done();
     });
 
@@ -615,7 +617,7 @@ describe('mapnik.VectorTile query point & line', function() {
                 "properties": { "name": "point" },
                 "geometry": {
                     "type": "Point",
-                    "coordinates": [ 20, 0 ]
+                    "coordinates": [ 100, 0 ]
                 }
             },{
                 "type": "Feature",
@@ -623,14 +625,14 @@ describe('mapnik.VectorTile query point & line', function() {
                 "geometry": {
                     "type": "LineString",
                     "coordinates": [
-                        [ -20, 0 ],
-                        [ 20, 0 ]
+                        [ -100, 0 ],
+                        [ 100, 0 ]
                     ]
                 }
         }]}),'data');
 
         //query on point
-        var data = vtile.query(20,0, { tolerance: 10000 });
+        var data = vtile.query(100,0, { tolerance: 10000 });
         assert.equal(data.length, 2);
         assert.equal(data[0].attributes().name, 'line')
         assert.equal(data[1].attributes().name, 'point')


### PR DESCRIPTION
This PR adds testing fixtures specific to querying streets/address points within a single layer of  a vector tile.

There are currently two problematic test cases.

### point on end line

A point and a line are added to the geocoder such that `-----o` the point is directly on top of the end of the line. One would expect that the end of the line (and therefore the point) were to be queried, both would be returned. Instead the tolerance must be increased to over `2000` before the point appears.

When the point is on the centre of the line as in the preceding test case, both the point and line are returned with a tolerance of 1 as expected.

### mapnik.VectorTile streets

This test simulates a fake city block with streets bordering each side and address points in the centre. Like the above test it queries each of the 5 points, expecting the point to be returned first. 

cc/ @flippmoke would love your :eyes: on this one to see if I'm missing something or whether this will require more investigation.