### PR TITLE
Return x,y hit for vtile.query

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "http://github.com/mapnik/node-mapnik",
   "homepage": "http://mapnik.org",
   "author": "Dane Springmeyer <dane@mapbox.com> (mapnik.org)",
-  "version": "3.4.14",
+  "version": "3.4.14-hits",
   "main": "./lib/mapnik.js",
   "binary": {
     "module_name": "mapnik",

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -155,37 +155,59 @@ std::vector<std::string> lazy_names(std::string const& buffer)
     return names;
 }
 
+struct p2p_result
+{
+    explicit p2p_result() :
+      distance(-1),
+      x_hit(0),
+      y_hit(0) {}
+
+    double distance;
+    double x_hit;
+    double y_hit;
+};
+
 struct p2p_distance
 {
     p2p_distance(double x, double y)
      : x_(x),
        y_(y) {}
 
-    double operator() (mapnik::geometry::geometry_empty const& ) const
+    p2p_result operator() (mapnik::geometry::geometry_empty const& ) const
     {
         // There is no current way that a geometry empty could be returned from a vector tile.
         /* LCOV_EXCL_START */
-        return -1;
+        p2p_result p2p;
+        return p2p;
         /* LCOV_EXCL_END */
     }
 
-    double operator() (mapnik::geometry::point<double> const& geom) const
+    p2p_result operator() (mapnik::geometry::point<double> const& geom) const
     {
-        return mapnik::distance(geom.x, geom.y, x_, y_);
+        p2p_result p2p;
+        p2p.x_hit = geom.x;
+        p2p.y_hit = geom.y;
+        p2p.distance = mapnik::distance(geom.x, geom.y, x_, y_);
+        return p2p;
     }
-    double operator() (mapnik::geometry::multi_point<double> const& geom) const
+    p2p_result operator() (mapnik::geometry::multi_point<double> const& geom) const
     {
-        double distance = -1;
+        p2p_result p2p;
         for (auto const& pt : geom)
         {
-            double dist = operator()(pt);
-            if (dist >= 0 && (distance < 0 || dist < distance)) distance = dist;
+            p2p_result p2p_sub = operator()(pt);
+            if (p2p_sub.distance >= 0 && (p2p.distance < 0 || p2p_sub.distance < p2p.distance))
+            {
+                p2p.x_hit = p2p_sub.x_hit;
+                p2p.y_hit = p2p_sub.y_hit;
+                p2p.distance = p2p_sub.distance;
+            }
         }
-        return distance;
+        return p2p;
     }
-    double operator() (mapnik::geometry::line_string<double> const& geom) const
+    p2p_result operator() (mapnik::geometry::line_string<double> const& geom) const
     {
-        double distance = -1;
+        p2p_result p2p;
         std::size_t num_points = geom.num_points();
         if (num_points > 1)
         {
@@ -194,26 +216,40 @@ struct p2p_distance
                 auto const& pt0 = geom[i-1];
                 auto const& pt1 = geom[i];
                 double dist = mapnik::point_to_segment_distance(x_,y_,pt0.x,pt0.y,pt1.x,pt1.y);
-                if (dist >= 0 && (distance < 0 || dist < distance)) distance = dist;
+                if (dist >= 0 && (p2p.distance < 0 || dist < p2p.distance))
+                {
+                    p2p.x_hit = pt0.x;
+                    p2p.y_hit = pt0.y;
+                    p2p.distance = dist;
+                }
             }
         }
-        return distance;
+        return p2p;
     }
-    double operator() (mapnik::geometry::multi_line_string<double> const& geom) const
+    p2p_result operator() (mapnik::geometry::multi_line_string<double> const& geom) const
     {
-        double distance = -1;
+        p2p_result p2p;
         for (auto const& line: geom)
         {
-            double dist = operator()(line);
-            if (dist >= 0 && (distance < 0 || dist < distance)) distance = dist;
+            p2p_result p2p_sub = operator()(line);
+            if (p2p_sub.distance >= 0 && (p2p.distance < 0 || p2p_sub.distance < p2p.distance))
+            {
+                p2p.x_hit = p2p_sub.x_hit;
+                p2p.y_hit = p2p_sub.y_hit;
+                p2p.distance = p2p_sub.distance;
+            }
         }
-        return distance;
+        return p2p;
     }
-    double operator() (mapnik::geometry::polygon<double> const& geom) const
+    p2p_result operator() (mapnik::geometry::polygon<double> const& geom) const
     {
         auto const& exterior = geom.exterior_ring;
         std::size_t num_points = exterior.num_points();
-        if (num_points < 4) return -1;
+        p2p_result p2p;
+        if (num_points < 4)
+        {
+            return p2p;
+        }
         bool inside = false;
         for (std::size_t i = 1; i < num_points; ++i)
         {
@@ -225,7 +261,10 @@ struct p2p_distance
                 inside = !inside;
             }
         }
-        if (!inside) return -1;
+        if (!inside)
+        {
+            return p2p;
+        }
         for (auto const& ring :  geom.interior_rings)
         {
             std::size_t num_interior_points = ring.size();
@@ -243,29 +282,43 @@ struct p2p_distance
                 }
             }
         }
-        return inside ? 0 : -1;
+        if (inside)
+        {
+            p2p.distance = 0;
+        }
+        return p2p;
     }
-    double operator() (mapnik::geometry::multi_polygon<double> const& geom) const
+    p2p_result operator() (mapnik::geometry::multi_polygon<double> const& geom) const
     {
-        double distance = -1;
+        p2p_result p2p;
         for (auto const& poly: geom)
         {
-            double dist = operator()(poly);
-            if (dist >= 0 && (distance < 0 || dist < distance)) distance = dist;
+            p2p_result p2p_sub = operator()(poly);
+            if (p2p_sub.distance >= 0 && (p2p.distance < 0 || p2p_sub.distance < p2p.distance))
+            {
+                p2p.x_hit = p2p_sub.x_hit;
+                p2p.y_hit = p2p_sub.y_hit;
+                p2p.distance = p2p_sub.distance;
+            }
         }
-        return distance;
+        return p2p;
     }
-    double operator() (mapnik::geometry::geometry_collection<double> const& collection) const
+    p2p_result operator() (mapnik::geometry::geometry_collection<double> const& collection) const
     {
         // There is no current way that a geometry collection could be returned from a vector tile.
         /* LCOV_EXCL_START */
-        double distance = -1;
+        p2p_result p2p;
         for (auto const& geom: collection)
         {
-            double dist = mapnik::util::apply_visitor((*this),geom);
-            if (dist >= 0 && (distance < 0 || dist < distance)) distance = dist;
+            p2p_result p2p_sub = mapnik::util::apply_visitor((*this),geom);
+            if (p2p_sub.distance >= 0 && (p2p.distance < 0 || p2p_sub.distance < p2p.distance))
+            {
+                p2p.x_hit = p2p_sub.x_hit;
+                p2p.y_hit = p2p_sub.y_hit;
+                p2p.distance = p2p_sub.distance;
+            }
         }
-        return distance;
+        return p2p;
         /* LCOV_EXCL_END */
     }
 
@@ -275,7 +328,7 @@ struct p2p_distance
 
 }
 
-double path_to_point_distance(mapnik::geometry::geometry<double> const& geom, double x, double y)
+detail::p2p_result path_to_point_distance(mapnik::geometry::geometry<double> const& geom, double x, double y)
 {
     return mapnik::util::apply_visitor(detail::p2p_distance(x,y), geom);
 }
@@ -1521,11 +1574,13 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                 while ((feature = fs->next()))
                 {
                     auto const& geom = feature->get_geometry();
-                    double distance = path_to_point_distance(geom,x,y);
-                    if (distance >= 0 && distance <= tolerance)
+                    auto p2p = path_to_point_distance(geom,x,y);
+                    if (p2p.distance >= 0 && p2p.distance <= tolerance)
                     {
                         query_result res;
-                        res.distance = distance;
+                        res.x_hit = p2p.x_hit;
+                        res.y_hit = p2p.y_hit;
+                        res.distance = p2p.distance;
                         res.layer = layer_name;
                         res.feature = feature;
                         arr.push_back(std::move(res));
@@ -1553,11 +1608,13 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                 while ((feature = fs->next()))
                 {
                     auto const& geom = feature->get_geometry();
-                    double distance = path_to_point_distance(geom,x,y);
-                    if (distance >= 0 && distance <= tolerance)
+                    auto p2p = path_to_point_distance(geom,x,y);
+                    if (p2p.distance >= 0 && p2p.distance <= tolerance)
                     {
                         query_result res;
-                        res.distance = distance;
+                        res.x_hit = p2p.x_hit;
+                        res.y_hit = p2p.y_hit;
+                        res.distance = p2p.distance;
                         res.layer = ds->get_name();
                         res.feature = feature;
                         arr.push_back(std::move(res));
@@ -1584,6 +1641,8 @@ v8::Local<v8::Array> VectorTile::_queryResultToV8(std::vector<query_result> cons
         v8::Local<v8::Object> feat_obj = feat->ToObject();
         feat_obj->Set(Nan::New("layer").ToLocalChecked(),Nan::New<v8::String>(item.layer).ToLocalChecked());
         feat_obj->Set(Nan::New("distance").ToLocalChecked(),Nan::New<v8::Number>(item.distance));
+        feat_obj->Set(Nan::New("x_hit").ToLocalChecked(),Nan::New<v8::Number>(item.x_hit));
+        feat_obj->Set(Nan::New("y_hit").ToLocalChecked(),Nan::New<v8::Number>(item.y_hit));
         arr->Set(i++,feat);
     }
     return arr;
@@ -1798,17 +1857,19 @@ void VectorTile::_queryMany(queryMany_result & result, VectorTile* d, std::vecto
                 for (std::size_t p = 0; p < points.size(); ++p) {
                     mapnik::coord2d const& pt = points[p];
                     auto const& geom = feature->get_geometry();
-                    double distance = path_to_point_distance(geom,pt.x,pt.y);
-                    if (distance >= 0 && distance <= tolerance)
+                    auto p2p = path_to_point_distance(geom,pt.x,pt.y);
+                    if (p2p.distance >= 0 && p2p.distance <= tolerance)
                     {
                         has_hit = 1;
                         query_result res;
+                        res.x_hit = p2p.x_hit;
+                        res.y_hit = p2p.y_hit;
                         res.feature = feature;
                         res.distance = 0;
                         res.layer = ds->get_name();
 
                         query_hit hit;
-                        hit.distance = distance;
+                        hit.distance = p2p.distance;
                         hit.feature_id = idx;
 
                         features.insert(std::make_pair(idx, res));

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -1542,6 +1542,7 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
     mapnik::projection wgs84("+init=epsg:4326",true);
     mapnik::projection merc("+init=epsg:3857",true);
     mapnik::proj_transform tr(wgs84,merc);
+    mapnik::proj_transform tr2(merc, wgs84);
     double x = lon;
     double y = lat;
     double z = 0;
@@ -1575,7 +1576,7 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                 {
                     auto const& geom = feature->get_geometry();
                     auto p2p = path_to_point_distance(geom,x,y);
-                    if (!tr.forward(p2p.x_hit,p2p.y_hit,z))
+                    if (!tr2.forward(p2p.x_hit,p2p.y_hit,z))
                     {
                         /* LCOV_EXCL_START */
                         throw std::runtime_error("could not reproject lon/lat to mercator");
@@ -1615,7 +1616,7 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                 {
                     auto const& geom = feature->get_geometry();
                     auto p2p = path_to_point_distance(geom,x,y);
-                    if (!tr.forward(p2p.x_hit,p2p.y_hit,z))
+                    if (!tr2.forward(p2p.x_hit,p2p.y_hit,z))
                     {
                         /* LCOV_EXCL_START */
                         throw std::runtime_error("could not reproject lon/lat to mercator");

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -1575,16 +1575,14 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                 {
                     auto const& geom = feature->get_geometry();
                     auto p2p = path_to_point_distance(geom,x,y);
+                    if (!tr.forward(p2p.x_hit,p2p.y_hit,z))
+                    {
+                        /* LCOV_EXCL_START */
+                        throw std::runtime_error("could not reproject lon/lat to mercator");
+                        /* LCOV_EXCL_END */
+                    }
                     if (p2p.distance >= 0 && p2p.distance <= tolerance)
                     {
-                        if (!tr.forward(p2p.x_hit,p2p.y_hit,z))
-                        {
-                            // THIS CAN NEVER BE REACHED CURRENTLY
-                            // internally lonlat2merc in mapnik can never return false.
-                            /* LCOV_EXCL_START */
-                            throw std::runtime_error("could not reproject lon/lat to mercator");
-                            /* LCOV_EXCL_END */
-                        }
                         query_result res;
                         res.x_hit = p2p.x_hit;
                         res.y_hit = p2p.y_hit;
@@ -1617,6 +1615,12 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                 {
                     auto const& geom = feature->get_geometry();
                     auto p2p = path_to_point_distance(geom,x,y);
+                    if (!tr.forward(p2p.x_hit,p2p.y_hit,z))
+                    {
+                        /* LCOV_EXCL_START */
+                        throw std::runtime_error("could not reproject lon/lat to mercator");
+                        /* LCOV_EXCL_END */
+                    }
                     if (p2p.distance >= 0 && p2p.distance <= tolerance)
                     {
                         query_result res;

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -1577,6 +1577,14 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                     auto p2p = path_to_point_distance(geom,x,y);
                     if (p2p.distance >= 0 && p2p.distance <= tolerance)
                     {
+                        if (!tr.forward(p2p.x_hit,p2p.y_hit,z))
+                        {
+                            // THIS CAN NEVER BE REACHED CURRENTLY
+                            // internally lonlat2merc in mapnik can never return false.
+                            /* LCOV_EXCL_START */
+                            throw std::runtime_error("could not reproject lon/lat to mercator");
+                            /* LCOV_EXCL_END */
+                        }
                         query_result res;
                         res.x_hit = p2p.x_hit;
                         res.y_hit = p2p.y_hit;

--- a/src/mapnik_vector_tile.hpp
+++ b/src/mapnik_vector_tile.hpp
@@ -20,7 +20,14 @@ struct query_lonlat {
 struct query_result {
     std::string layer;
     double distance;
+    double x_hit;
+    double y_hit;
     mapnik::feature_ptr feature;
+    explicit query_result() :
+     layer(),
+     distance(0),
+     x_hit(0),
+     y_hit(0) {}
 };
 
 struct query_hit {

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -631,10 +631,10 @@ describe('mapnik.VectorTile query xy single features', function() {
             }]
         }),"layer-name");
         var res = vtile.query(0.015, -0.005, {tolerance:10000});
-        assert.deepEqual([res[0].x_hit, res[0].y_hit], [ 1669.6713366043189, -556.5571122014396 ]);
-        assert.deepEqual([res[1].x_hit, res[1].y_hit], [ 1669.6713366043189, -1669.6713366043189]);
-        assert.deepEqual([res[2].x_hit, res[2].y_hit], [  556.5571122014396, -556.5571122014396]);
-        assert.deepEqual([res[3].x_hit, res[3].y_hit], [  556.5571122014396, -1669.6713366043189]);
+        assert.deepEqual([res[0].x_hit, res[0].y_hit], [ 0.014998912811279297, -0.0049996375974215084 ]);
+        assert.deepEqual([res[1].x_hit, res[1].y_hit], [ 0.014998912811279297, -0.0149989126399668430 ]);
+        assert.deepEqual([res[2].x_hit, res[2].y_hit], [ 0.004999637603759766, -0.0049996375974215084 ]);
+        assert.deepEqual([res[3].x_hit, res[3].y_hit], [ 0.004999637603759766, -0.0149989126399668430 ]);
         done();
     });
 });

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -511,3 +511,85 @@ describe('mapnik.VectorTile query (distance <= tolerance)', function() {
     });
 });
 
+describe('mapnik.VectorTile query xy single features', function() {
+    it('Point', function(done) {
+        var vtile = new mapnik.VectorTile(0,0,0);
+        vtile.addGeoJSON(JSON.stringify({
+          "type": "FeatureCollection",
+          "features": [{
+            "type": "Feature",
+            "geometry": {
+              "type": "Point",
+              "coordinates": [ 0,0 ]
+            },
+            "properties": { "name": "A" }
+          }]
+        }),"layer-name");
+        var res = vtile.query(0,0,{tolerance:1});
+        assert.equal(res[0].x_hit, 0);
+        assert.equal(res[0].y_hit, 0);
+        assert.equal(res[0].attributes().name, 'A');
+        done();
+    });
+
+    it('MultiPoint', function(done) {
+        var vtile = new mapnik.VectorTile(0,0,0);
+        vtile.addGeoJSON(JSON.stringify({
+          "type": "FeatureCollection",
+          "features": [{
+            "type": "Feature",
+            "geometry": {
+              "type": "MultiPoint",
+              "coordinates": [[ 0,0 ]]
+            },
+            "properties": { "name": "A" }
+          }]
+        }),"layer-name");
+        var res = vtile.query(0,0,{tolerance:1});
+        assert.equal(res[0].x_hit, 0);
+        assert.equal(res[0].y_hit, 0);
+        assert.equal(res[0].attributes().name, 'A');
+        done();
+    });
+
+    it('LineString', function(done) {
+        var vtile = new mapnik.VectorTile(0,0,0);
+        vtile.addGeoJSON(JSON.stringify({
+          "type": "FeatureCollection",
+          "features": [{
+            "type": "Feature",
+            "geometry": {
+              "type": "LineString",
+              "coordinates": [ [ 0,0 ], [100, 100] ]
+            },
+            "properties": { "name": "A" }
+          }]
+        }),"layer-name");
+        var res = vtile.query(0,0,{tolerance:1});
+        assert.equal(res[0].x_hit, 0);
+        assert.equal(res[0].y_hit, 0);
+        assert.equal(res[0].attributes().name, 'A');
+        done();
+    });
+
+    it('MultiLineString', function(done) {
+        var vtile = new mapnik.VectorTile(0,0,0);
+        vtile.addGeoJSON(JSON.stringify({
+          "type": "FeatureCollection",
+          "features": [{
+            "type": "Feature",
+            "geometry": {
+              "type": "MultiLineString",
+              "coordinates": [ [ [ 0,0 ], [100, 100] ] ]
+            },
+            "properties": { "name": "A" }
+          }]
+        }),"layer-name");
+        var res = vtile.query(0,0,{tolerance:1});
+        assert.equal(res[0].x_hit, 0);
+        assert.equal(res[0].y_hit, 0);
+        assert.equal(res[0].attributes().name, 'A');
+        done();
+    });
+});
+

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -591,5 +591,51 @@ describe('mapnik.VectorTile query xy single features', function() {
         assert.equal(res[0].attributes().name, 'A');
         done();
     });
+
+    // -------
+    // | . . |
+    // | . . |
+    // -------
+    it('Multiple Points', function(done) {
+        var vtile = new mapnik.VectorTile(14,8192,8192);
+        vtile.addGeoJSON(JSON.stringify({
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [ 0.005, -0.015 ]
+                },
+                "properties": { "name": "Point A" }
+            },{
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [ 0.015,-0.015 ]
+                },
+                "properties": { "name": "Point B" }
+            },{
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [ 0.015, -0.005 ]
+                },
+                "properties": { "name": "Point C" }
+            },{
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [ 0.005,-0.005 ]
+                },
+                "properties": { "name": "Point D" }
+            }]
+        }),"layer-name");
+        var res = vtile.query(0.015, -0.005, {tolerance:10000});
+        assert.deepEqual([res[0].x_hit, res[0].y_hit], [ 1669.6713366043189, -556.5571122014396 ]);
+        assert.deepEqual([res[1].x_hit, res[1].y_hit], [ 1669.6713366043189, -1669.6713366043189]);
+        assert.deepEqual([res[2].x_hit, res[2].y_hit], [  556.5571122014396, -556.5571122014396]);
+        assert.deepEqual([res[3].x_hit, res[3].y_hit], [  556.5571122014396, -1669.6713366043189]);
+        done();
+    });
 });
 

--- a/test/vector-tile.query.test.js
+++ b/test/vector-tile.query.test.js
@@ -48,6 +48,8 @@ describe('mapnik.VectorTile query polygon', function() {
             assert.equal(features[0].id(),89);
             assert.equal(features[0].geometry().type(),mapnik.Geometry.Polygon);
             assert.equal(features[0].distance,0);
+            assert.equal(features[0].x_hit,0);
+            assert.equal(features[0].y_hit,0);
             assert.equal(features[0].layer,'world');
         }
     });
@@ -191,6 +193,8 @@ describe('mapnik.VectorTile query point', function() {
             assert.equal(features[0].id(),1);
             assert.equal(features[0].geometry().type(),mapnik.Geometry.Point);
             assert.ok(Math.abs(features[0].distance - 1888.66) < 1);
+            assert.ok(Math.abs(features[0].x_hit - -13580108) < 1);
+            assert.ok(Math.abs(features[0].y_hit - 6105178.3) < 1);
             assert.equal(features[0].layer,'layer-name');
         }
     });


### PR DESCRIPTION
Currently `vtile.query` returns an array of features with custom properties added:

  - distance
  - layer name

@ingalls would also like to know the corresponding x,y that was matched for a given search.

The meaning of that `x,y` would differ per geometry type:

 - Point: the actual x,y of the single point
 - MultiPoint: the x,y of the single point within the multipoint that is closest to the query x,y
 - LineString: the vertex closest to the query x,y
 - MultiLinestring: the vertex closest to the query x,y for the geometry part closest to the query x,y
 - Multi(Polygon): not supported (since we don't support distance)

This pull starts sketching this out.

TODO:

  - [ ] Tests of all geometry types
  - [ ] x,y are currently returned in web mercator (likely should reproject to EPSG:4326)