### PR TITLE
[notready] Init before resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "http://github.com/mapnik/node-mapnik",
   "homepage": "http://mapnik.org",
   "author": "Dane Springmeyer <dane@mapbox.com> (mapnik.org)",
-  "version": "3.4.15",
+  "version": "3.4.15-init",
   "main": "./lib/mapnik.js",
   "binary": {
     "module_name": "mapnik",

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -2025,7 +2025,7 @@ v8::Local<v8::Value> Image::_resizeSync(Nan::NAN_METHOD_ARGS_TYPE info)
         std::shared_ptr<mapnik::image_any> image_ptr = std::make_shared<mapnik::image_any>(width, 
                                                            height, 
                                                            im->this_->get_dtype(),
-                                                           false,
+                                                           true,
                                                            true,
                                                            false);
         image_ptr->set_offset(offset);

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -1845,7 +1845,7 @@ void Image::EIO_Resize(uv_work_t* req)
         closure->im2 = std::make_shared<mapnik::image_any>(closure->size_x, 
                                                            closure->size_y, 
                                                            closure->im1->this_->get_dtype(),
-                                                           false,
+                                                           true,
                                                            true,
                                                            false);
         closure->im2->set_offset(offset);

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -1527,4 +1527,15 @@ describe('mapnik.Image ', function() {
             })();
         });
     });
+
+    it('resizes consistently (sync)', function(done) {
+        var data = require('fs').readFileSync(__dirname + '/support/a.png');
+        var image = mapnik.Image.fromBytesSync(data);
+        image.premultiplySync();
+        var control = image.resizeSync(64, 64);
+        for (var i = 0; i < 100; i++) {
+            assert.equal(control.compare(image.resizeSync(64, 64), {}), 0);
+        }
+        done();
+    });
 });


### PR DESCRIPTION
- Adds testcases (async + sync) for ensuring resize generates identical output when run repeatedly/at concurrency. See test only branch fail against master here: https://github.com/mapnik/node-mapnik/compare/resize-garbage-testcase?expand=1
- @springmeyer's fix by initializing the dest image

cc @springmeyer for your review