### PR TITLE
Avoid equality comparisons of floating point numbers

### DIFF
--- a/src/tint.hpp
+++ b/src/tint.hpp
@@ -16,9 +16,9 @@ static inline void rgb_to_hsl(unsigned red, unsigned green, unsigned blue,
     h = 0.0, s = 0.0, l = gamma / 2.0;
     if (delta > 0.0) {
         s = l > 0.5 ? delta / (2.0 - gamma) : delta / gamma;
-        if (max == r && max != g) h = (g - b) / delta + (g < b ? 6.0 : 0.0);
-        if (max == g && max != b) h = (b - r) / delta + 2.0;
-        if (max == b && max != r) h = (r - g) / delta + 4.0;
+        if (r >= b && r > g) h = (g - b) / delta + (g < b ? 6.0 : 0.0);
+        if (g >= r && g > b) h = (b - r) / delta + 2.0;
+        if (b >= g && b > r) h = (r - g) / delta + 4.0;
         h /= 6.0;
     }
 }


### PR DESCRIPTION
Equality comparisons of floating point numbers are always dangerous and this case the code was actually failing on x86 with gcc 6 because one side of the comparison was still in a register and hence had 80 bit precision while the other side had been stored to memory and reduced to 64 bit precision:

https://bugzilla.redhat.com/show_bug.cgi?id=1303315
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69570