### PR TITLE
Add building/testing/publishing of Debug builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
        env: NODE_VERSION="4" # node abi 46
      - os: linux
        compiler: clang
-       env: NODE_VERSION="0.12" # node abi 14
+       env: NODE_VERSION="0.10" DEBUG=true # node abi 11
      - os: linux
        compiler: clang
        env: NODE_VERSION="0.10" # node abi 11
@@ -58,7 +58,7 @@ matrix:
      - os: osx
        osx_image: xcode7
        compiler: clang
-       env: NODE_VERSION="0.12" # node abi 14
+       env: NODE_VERSION="0.10" DEBUG=true # node abi 11
      - os: osx
        osx_image: xcode7
        compiler: clang

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,8 +1,5 @@
 {
   'includes': [ 'common.gypi' ],
-  'variables': {
-    'coverage': 'false'
-  },
   'targets': [
     {
       'target_name': 'make_vector_tile',
@@ -71,17 +68,6 @@
           'CLIPPER_IMPL_INCLUDE=<mapnik/geometry.hpp>'
       ],
       'conditions': [
-        ["coverage == 'true'", {
-            "cflags_cc": ["--coverage"],
-            "xcode_settings": {
-                "OTHER_CPLUSPLUSFLAGS":[
-                    "--coverage"
-                ],
-                'OTHER_LDFLAGS':[
-                    '--coverage'
-                ]
-            }
-        }],
         ['OS=="win"',
           {
             'include_dirs':[

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "module_name": "mapnik",
     "module_path": "./lib/binding/{node_abi}-{platform}-{arch}",
     "host": "https://mapbox-node-binary.s3.amazonaws.com",
-    "remote_path": "./{module_name}/v{version}/",
+    "remote_path": "./{module_name}/v{version}/{configuration}/",
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
   },
   "bugs": {

--- a/scripts/build_against_sdk.sh
+++ b/scripts/build_against_sdk.sh
@@ -13,7 +13,7 @@ if [[ ${MAPNIK_GIT:-unset} == "unset" ]]; then
     exit 1
 fi
 
-ARGS=""
+ARGS="$@"
 CURRENT_DIR="$( cd "$( dirname $BASH_SOURCE )" && pwd )"
 mkdir -p $CURRENT_DIR/../sdk
 cd $CURRENT_DIR/../
@@ -21,10 +21,6 @@ export PATH=$(pwd)/node_modules/.bin:${PATH}
 cd sdk
 BUILD_DIR="$(pwd)"
 UNAME=$(uname -s);
-
-if [[ ${1:-false} != false ]]; then
-    ARGS=$1
-fi
 
 
 COMPRESSION="tar.bz2"
@@ -69,10 +65,12 @@ if [[ ! `which node` ]]; then
 fi
 
 if [[ $UNAME == 'Linux' ]]; then
-    readelf -d $MAPNIK_SDK/lib/libmapnik.so
     export LDFLAGS='-Wl,-z,origin -Wl,-rpath=\$$ORIGIN'
-else
-    otool -L $MAPNIK_SDK/lib/libmapnik.dylib
+fi
+
+if [[ ${COVERAGE:-false} == true ]]; then
+    export LDFLAGS="--coverage $LDFLAGS"
+    export CXXFLAGS="--coverage $CXXFLAGS"
 fi
 
 cd ../
@@ -80,8 +78,12 @@ npm install node-pre-gyp
 MODULE_PATH=$(node-pre-gyp reveal module_path ${ARGS})
 # note: dangerous!
 rm -rf ${MODULE_PATH}
-npm install --build-from-source ${ARGS} --clang=1
-npm ls
+if [[ ${DEBUG:-false} == true ]] || [[ ${COVERAGE:-false} == true ]]; then
+    npm install --build-from-source ${ARGS} --clang=1 --debug
+else
+    npm install --build-from-source ${ARGS} --clang=1
+fi
+
 # copy mapnik-index
 cp ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}
 # copy shapeindex

--- a/scripts/build_against_sdk.sh
+++ b/scripts/build_against_sdk.sh
@@ -68,7 +68,7 @@ export LDFLAGS=${LDFLAGS:-""}
 export CXXFLAGS=${CXXFLAGS:-""}
 
 if [[ $UNAME == 'Linux' ]]; then
-    export LDFLAGS='-Wl,-z,origin -Wl,-rpath=\$$ORIGIN ${LDFLAGS}'
+    export LDFLAGS='-Wl,-z,origin -Wl,-rpath=\$$ORIGIN '${LDFLAGS}
 fi
 
 if [[ ${COVERAGE:-false} == true ]]; then

--- a/scripts/build_against_sdk.sh
+++ b/scripts/build_against_sdk.sh
@@ -64,13 +64,16 @@ if [[ ! `which node` ]]; then
     exit 1
 fi
 
+export LDFLAGS=${LDFLAGS:-""}
+export CXXFLAGS=${CXXFLAGS:-""}
+
 if [[ $UNAME == 'Linux' ]]; then
-    export LDFLAGS='-Wl,-z,origin -Wl,-rpath=\$$ORIGIN'
+    export LDFLAGS='-Wl,-z,origin -Wl,-rpath=\$$ORIGIN ${LDFLAGS}'
 fi
 
 if [[ ${COVERAGE:-false} == true ]]; then
-    export LDFLAGS="--coverage $LDFLAGS"
-    export CXXFLAGS="--coverage $CXXFLAGS"
+    export LDFLAGS="--coverage ${LDFLAGS}"
+    export CXXFLAGS="--coverage ${CXXFLAGS}"
 fi
 
 cd ../


### PR DESCRIPTION
The idea here is that you can install node-mapnik from binaries like:

```
npm install --debug --fallback-to-build=false
```

And get binaries instrumented such that backtraces are detailed with line numbers.

Closes #606

/cc @flippmoke @yhahn @mapsam