### PR TITLE
quick command to get info from a tile

### DIFF
--- a/bin/mapnik-info.js
+++ b/bin/mapnik-info.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var exists = require('fs').existsSync || require('path').existsSync;
+var fs = require('fs');
+var usage = 'usage:';
+usage += '\n  mapnik-info.js <single vector tile> (.vector.pbf|.mvt)';
+
+var tile = process.argv[2];
+
+if (!tile) {
+   console.log(usage);
+   process.exit(1);
+}
+
+if (!exists(tile)) {
+    console.log(tile + ' does not exist');
+    process.exit(1);
+}
+
+var mapnik = require('../');
+mapnik.register_default_input_plugins();
+
+var buffer = fs.readFileSync(tile);
+console.log(mapnik.VectorTile.info(buffer));

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "bin": {
     "mapnik-inspect.js": "./bin/mapnik-inspect.js",
     "mapnik-render.js": "./bin/mapnik-render.js",
-    "mapnik-shapeindex.js": "./bin/mapnik-shapeindex.js"
+    "mapnik-shapeindex.js": "./bin/mapnik-shapeindex.js",
+    "mapnik-info.js": "./bin/mapnik-info.js"
   },
   "scripts": {
     "prepublish": "npm ls",


### PR DESCRIPTION
In interest of getting the information from a `.mvt` or `.vector.pbf` quickly, this is a `bin` command to log that information to the console.

Usage:

```
mapnik-info.js <tile>
```

Output example:

```
{ layers: 
   [ { name: 'nps_land_clip_pg',
       features: 1,
       point_features: 0,
       linestring_features: 0,
       polygon_features: 1,
       unknown_features: 0,
       raster_features: 0,
       version: 1 },
     { name: 'nps_park_polys',
       features: 1,
       point_features: 0,
       linestring_features: 0,
       polygon_features: 1,
       unknown_features: 0,
       raster_features: 0,
       version: 1 } ],
  errors: false }
```

cc @flippmoke @ajashton @springmeyer @artemp 