### PR TITLE
rebundle `node-pre-gyp` and do not preinstall it

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "node-pre-gyp": "~0.6.26",
     "protozero": "~1.3.0"
   },
+  "bundledDependencies": [
+    "node-pre-gyp"
+  ],
   "bin": {
     "mapnik-inspect.js": "./bin/mapnik-inspect.js",
     "mapnik-render.js": "./bin/mapnik-render.js",
@@ -54,7 +57,6 @@
   "scripts": {
     "prepublish": "npm ls",
     "test": "jshint bin lib/index.js lib/mapnik.js && mocha -R spec --timeout 50000",
-    "preinstall":"npm install node-pre-gyp",
     "install": "node-pre-gyp install --fallback-to-build",
     "docs": "documentation src/*.cpp --polyglot -o documentation -f html --github --name Mapnik"
   },


### PR DESCRIPTION
Partially reverts df7d542885781a7949fef4dccc030a71f8d8c985 to prevent an endless loop in npm v3.

Fixes #650, #640, #630.