### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -1825,7 +1825,7 @@ NAN_METHOD(Image::resize)
     }
     else
     {
-        Nan::ThrowTypeError("resize requires a width and height paramter.");
+        Nan::ThrowTypeError("resize requires a width and height parameter.");
         return;
     }
     if (info.Length() >= 4)

--- a/src/mapnik_projection.cpp
+++ b/src/mapnik_projection.cpp
@@ -56,7 +56,7 @@ NAN_METHOD(Projection::New)
     }
 
     if (info.Length() <= 0 || !info[0]->IsString()) {
-        Nan::ThrowTypeError("please provide a proj4 intialization string");
+        Nan::ThrowTypeError("please provide a proj4 initialization string");
         return;
     }
     bool lazy = false;

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -4880,12 +4880,12 @@ NAN_METHOD(VectorTile::render)
         {
             if (!set_z || !set_x || !set_y)
             {
-                Nan::ThrowTypeError("orginal args 'z', 'x', and 'y' must all be used together");
+                Nan::ThrowTypeError("original args 'z', 'x', and 'y' must all be used together");
                 return;
             }
             if (closure->x < 0 || closure->y < 0 || closure->z < 0)
             {
-                Nan::ThrowTypeError("orginal args 'z', 'x', and 'y' can not be negative");
+                Nan::ThrowTypeError("original args 'z', 'x', and 'y' can not be negative");
                 return;
             }
             int max_at_zoom = pow(2,closure->z);


### PR DESCRIPTION
These spelling errors were reported by the lintian QA tool for the Debian package build:

 paramter      -> parameter
 intialization -> initialization
 orginal       -> original