### PR TITLE
Add Geometry#typeName method [publish docs]

### DIFF
--- a/lib/mapnik.js
+++ b/lib/mapnik.js
@@ -111,7 +111,7 @@ function getGeometryType(mapnikType) {
 
 mapnik.Geometry.prototype.typeName = function() {
   return getGeometryType(this.type());
-}
+};
 
 mapnik.Feature.prototype.toWKB = function() {
     return this.geometry().toWKB();

--- a/lib/mapnik.js
+++ b/lib/mapnik.js
@@ -86,6 +86,33 @@ if (process.env.MAPNIK_FONT_PATH) {
     });
 }
 
+function getGeometryType(mapnikType) {
+  switch (mapnikType) {
+    case mapnik.Geometry.Point:
+      return 'Point';
+    case mapnik.Geometry.LineString:
+      return 'LineString';
+    case mapnik.Geometry.Polygon:
+      return 'Polygon';
+    case mapnik.Geometry.MultiPoint:
+      return 'MultiPoint';
+    case mapnik.Geometry.MultiLineString:
+      return 'MultiLineString';
+    case mapnik.Geometry.MultiPolygon:
+      return 'MultiPolygon';
+    case mapnik.Geometry.GeometryCollection:
+      return 'GeometryCollection';
+    case mapnik.Geometry.Unknown:
+      return 'Unknown';
+    default:
+      return 'Unknown';
+  }
+}
+
+mapnik.Geometry.prototype.typeName = function() {
+  return getGeometryType(this.type());
+}
+
 mapnik.Feature.prototype.toWKB = function() {
     return this.geometry().toWKB();
 };

--- a/src/mapnik_geometry.cpp
+++ b/src/mapnik_geometry.cpp
@@ -12,7 +12,7 @@ Nan::Persistent<v8::FunctionTemplate> Geometry::constructor;
 
 /**
  * **`mapnik.Geometry`**
- * 
+ *
  * Geometry: a representation of geographical features in terms of
  * shape alone. This class provides many useful functions for conversion
  * to and from formats.
@@ -379,3 +379,13 @@ NAN_METHOD(Geometry::toWKB)
     }
     info.GetReturnValue().Set(Nan::CopyBuffer(wkb->buffer(), wkb->size()).ToLocalChecked());
 }
+
+/**
+ * Get the geometry's representation as a GeoJSON type
+ *
+ * @name typeName
+ * @memberof Geometry
+ * @instance
+ * @returns {string} GeoJSON type representation of this geometry
+ */
+// Function exists in mapnik.js

--- a/test/geometry.test.js
+++ b/test/geometry.test.js
@@ -30,7 +30,7 @@ describe('mapnik.Geometry ', function() {
         var expected_wkb = new Buffer('0104000000020000000101000000000000000000000000000000000000000101000000000000000000f03f000000000000f03f', 'hex');
         assert.deepEqual(geom.toWKB(),expected_wkb);
     });
-    
+
     it('should fail on toJSON due to bad parameters', function() {
         var feature = new mapnik.Feature(1);
         var point = {
@@ -71,5 +71,144 @@ describe('mapnik.Geometry ', function() {
         assert.throws(function() {
             var geom = s.geometry().toWKB();
         });
+    });
+
+    it('should return a type name for a Point', function() {
+        var input = {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Point',
+                coordinates: [ 10, 15 ]
+            }
+        };
+        var f = new mapnik.Feature.fromJSON(JSON.stringify(input));
+        var geom = f.geometry();
+        assert.equal(geom.typeName(), 'Point');
+    });
+
+    it('should return a type name for a LineString', function() {
+        var input = {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'LineString',
+                coordinates: [[ 10, 15 ], [ 20, 30 ]]
+            }
+        };
+        var f = new mapnik.Feature.fromJSON(JSON.stringify(input));
+        var geom = f.geometry();
+        assert.equal(geom.typeName(), 'LineString');
+    });
+
+    it('should return a type name for a Polygon', function() {
+        var input = {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Polygon',
+                coordinates: [[[ 10, 15 ], [ 20, 30 ], [ 40, 30 ], [ 10, 15 ]]]
+            }
+        };
+        var f = new mapnik.Feature.fromJSON(JSON.stringify(input));
+        var geom = f.geometry();
+        assert.equal(geom.typeName(), 'Polygon');
+    });
+
+    it('should return a type name for a MultiPoint', function() {
+        var input = {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: [[ 10, 15 ], [ 20, 30 ]]
+            }
+        };
+        var f = new mapnik.Feature.fromJSON(JSON.stringify(input));
+        var geom = f.geometry();
+        assert.equal(geom.typeName(), 'MultiPoint');
+    });
+
+    it('should return a type name for a MultiLineString', function() {
+        var input = {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'MultiLineString',
+                coordinates: [[[ 10, 15 ], [ 20, 30 ]], [[ 40, 30 ], [ 10, 15 ]]]
+            }
+        };
+        var f = new mapnik.Feature.fromJSON(JSON.stringify(input));
+        var geom = f.geometry();
+        assert.equal(geom.typeName(), 'MultiLineString');
+    });
+
+    it('should return a type name for a MultiPolygon', function() {
+        var input = {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'MultiPolygon',
+                coordinates: [
+                    [[[ 10, 15 ], [ 20, 30 ], [ 40, 30 ], [ 10, 15 ]]],
+                    [[[ 40, 55 ], [ 60, 70 ], [ 80, 70 ], [ 40, 55 ]]]
+                ]
+            }
+        };
+        var f = new mapnik.Feature.fromJSON(JSON.stringify(input));
+        var geom = f.geometry();
+        assert.equal(geom.typeName(), 'MultiPolygon');
+    });
+
+    it('should return a type name for a GeometryCollection', function() {
+        var input = {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'GeometryCollection',
+                geometries: [
+                    {
+                        type: 'LineString',
+                        coordinates: [[ 10, 15 ], [ 20, 30 ]]
+                    },
+                    {
+                        type: 'Point',
+                        coordinates: [ 10, 15 ]
+                    }
+                ]
+            }
+        };
+        var f = new mapnik.Feature.fromJSON(JSON.stringify(input));
+        var geom = f.geometry();
+        assert.equal(geom.typeName(), 'GeometryCollection');
+    });
+
+    it('should return a type name for an unknown geometry', function() {
+        var input = {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'MultiPoint',
+                coordinates: [ 10, 15 ]
+            }
+        };
+        var f = new mapnik.Feature.fromJSON(JSON.stringify(input));
+        var geom = f.geometry();
+        assert.equal(geom.typeName(), 'Unknown');
+    });
+
+    it('should return a type name for a broken geometry', function() {
+        var input = {
+            type: 'Feature',
+            properties: {},
+            geometry: {
+                type: 'Point',
+                coordinates: [ 10, 15 ]
+            }
+        };
+        var f = new mapnik.Feature.fromJSON(JSON.stringify(input));
+        var geom = f.geometry();
+        geom.type = function() { return 777; }
+        assert.equal(geom.typeName(), 'Unknown');
     });
 });


### PR DESCRIPTION
Closes #670.

cc @springmeyer.

I was unable to get the documentation generated locally (Am I missing something? Is there a particular `documentation` version you need globally installed?), but tried adding a docblock comment to the relevant `*.cpp` file.