### PR TITLE
no more DOC_JOB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
      # Linux
      - os: linux
        compiler: clang
-       env: NODE_VERSION="6" DOC_JOB=true PUBLISHABLE=true # node abi 48
+       env: NODE_VERSION="6" PUBLISHABLE=true # node abi 48
      - os: linux
        compiler: clang
        env: NODE_VERSION="5" PUBLISHABLE=true # node abi 47


### PR DESCRIPTION
Remove the `DOC_JOB` env variable since we are no longer running docs via commit messages.