### PR TITLE
[WIP] consistency for empty featuresets

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://mapnik.org",
   "author": "Dane Springmeyer <dane@mapbox.com> (mapnik.org)",
   "version": "3.5.14",
-  "mapnik_version":"v3.0.12-rc2",
+  "mapnik_version":"v3.0.12-rc6-22-gc67e505",
   "main": "./lib/mapnik.js",
   "binary": {
     "module_name": "mapnik",

--- a/src/mapnik_datasource.cpp
+++ b/src/mapnik_datasource.cpp
@@ -237,6 +237,8 @@ NAN_METHOD(Datasource::describe)
  * @name featureset
  * @memberof Datasource
  * @instance
+ * @param {Object} [options]
+ * @param {Array<number>} [options.extent=[minx,miny,maxx,maxy]]
  * @returns {Object} an iterator with a `.next()` method that returns
  * features from a dataset.
  * @example
@@ -250,10 +252,49 @@ NAN_METHOD(Datasource::describe)
 NAN_METHOD(Datasource::featureset)
 {
     Datasource* ds = Nan::ObjectWrap::Unwrap<Datasource>(info.Holder());
+    mapnik::box2d<double> extent = ds->datasource_->envelope();
+    if (info.Length() > 0)
+    {
+        // options object
+        if (!info[0]->IsObject())
+        {
+            Nan::ThrowTypeError("optional second argument must be an options object");
+            return;
+        }
+        v8::Local<v8::Object> options = info[0]->ToObject();
+        if (options->Has(Nan::New("extent").ToLocalChecked()))
+        {
+            v8::Local<v8::Value> extent_opt = options->Get(Nan::New("extent").ToLocalChecked());
+            if (!extent_opt->IsArray())
+            {
+                Nan::ThrowTypeError("extent value must be an array of [minx,miny,maxx,maxy]");
+                return;
+            }
+            v8::Local<v8::Array> bbox = extent_opt.As<v8::Array>();
+            auto len = bbox->Length();
+            if (!(len == 4))
+            {
+                Nan::ThrowTypeError("extent value must be an array of [minx,miny,maxx,maxy]");
+                return;
+            }
+            v8::Local<v8::Value> minx = bbox->Get(0);
+            v8::Local<v8::Value> miny = bbox->Get(1);
+            v8::Local<v8::Value> maxx = bbox->Get(2);
+            v8::Local<v8::Value> maxy = bbox->Get(3);
+            if (!minx->IsNumber() || !miny->IsNumber() || !maxx->IsNumber() || !maxy->IsNumber())
+            {
+                Nan::ThrowError("max_extent [minx,miny,maxx,maxy] must be numbers");
+                return;
+            }
+            extent = mapnik::box2d<double>(minx->NumberValue(),miny->NumberValue(),
+                                           maxx->NumberValue(),maxy->NumberValue());
+        }
+    }
+
     mapnik::featureset_ptr fs;
     try
     {
-        mapnik::query q(ds->datasource_->envelope());
+        mapnik::query q(extent);
         mapnik::layer_descriptor ld = ds->datasource_->get_descriptor();
         auto const& desc = ld.get_descriptors();
         for (auto const& attr_info : desc)
@@ -275,7 +316,7 @@ NAN_METHOD(Datasource::featureset)
         /* LCOV_EXCL_STOP */
     }
 
-    if (fs)
+    if (fs && mapnik::is_valid(fs))
     {
         info.GetReturnValue().Set(Featureset::NewInstance(fs));
     }

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -1707,7 +1707,7 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                                             d->tile_->y(),
                                             d->tile_->z());
             mapnik::featureset_ptr fs = ds->features_at_point(pt, tolerance);
-            if (fs)
+            if (fs && mapnik::is_valid(fs))
             {
                 mapnik::feature_ptr feature;
                 while ((feature = fs->next()))
@@ -1746,7 +1746,7 @@ std::vector<query_result> VectorTile::_query(VectorTile* d, double lon, double l
                                             d->tile_->y(),
                                             d->tile_->z());
             mapnik::featureset_ptr fs = ds->features_at_point(pt,tolerance);
-            if (fs)
+            if (fs && mapnik::is_valid(fs))
             {
                 mapnik::feature_ptr feature;
                 while ((feature = fs->next()))
@@ -2045,7 +2045,7 @@ void VectorTile::_queryMany(queryMany_result & result,
     }
     mapnik::featureset_ptr fs = ds->features(q);
 
-    if (fs)
+    if (fs && mapnik::is_valid(fs))
     {
         mapnik::feature_ptr feature;
         unsigned idx = 0;
@@ -2742,7 +2742,7 @@ bool layer_to_geojson(protozero::pbf_reader const& layer,
     }
     mapnik::featureset_ptr fs = ds.features(q);
     bool first = true;
-    if (fs)
+    if (fs && mapnik::is_valid(fs))
     {
         mapnik::feature_ptr feature;
         while ((feature = fs->next()))
@@ -5490,7 +5490,7 @@ void layer_not_simple(protozero::pbf_reader const& layer_msg,
         q.add_property_name(item.get_name());
     }
     mapnik::featureset_ptr fs = ds.features(q);
-    if (fs)
+    if (fs && mapnik::is_valid(fs))
     {
         mapnik::feature_ptr feature;
         while ((feature = fs->next()))
@@ -5796,7 +5796,7 @@ void layer_not_valid(protozero::pbf_reader & layer_msg,
             q.add_property_name(item.get_name());
         }
         mapnik::featureset_ptr fs = ds.features(q);
-        if (fs)
+        if (fs && mapnik::is_valid(fs))
         {
             mapnik::feature_ptr feature;
             while ((feature = fs->next()))

--- a/test/data/parse.error.json
+++ b/test/data/parse.error.json
@@ -1,0 +1,8 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "oofda"
+    }
+  ]
+}

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -174,6 +174,50 @@ describe('mapnik.Datasource', function() {
         assert.equal(false, ds.add({}));
     });
 
+    it('test empty memory datasource', function() {
+        var ds = new mapnik.MemoryDatasource({'extent': '-180,-90,180,90'});
+        var empty_fs = ds.featureset();
+        assert.equal(typeof(empty_fs),'undefined');
+        assert.equal(empty_fs, null);
+    });
+
+    it('test empty geojson datasource', function() {
+        var input = {
+          "type": "Feature",
+          "properties": {
+            "something": []
+          },
+          "geometry": {
+            "type": "Point",
+            "coordinates": [ 1, 1 ]
+          }
+        };
+        var ds = new mapnik.Datasource({ type:'geojson', inline: JSON.stringify(input) });
+        var fs = ds.featureset()
+        var feat = fs.next();
+        var feature = JSON.parse(feat.toJSON());
+        // pass invalid extent to filter all features out
+        // resulting in empty featureset that should be returned
+        // as a null object
+        var empty_fs = ds.featureset({extent:[-1,-1,0,0]});
+        assert.equal(typeof(empty_fs),'undefined');
+        assert.equal(empty_fs, null);
+    });
+
+    it('test empty geojson datasource due to invalid json string', function() {
+        var input = "{ \"type\": \"FeatureCollection\", \"features\": [{ \"oofda\" } ] }";
+        // from string will fail to parse
+        assert.throws(function() { new mapnik.Datasource({ type:'geojson', inline: inline, cache_features: false }); });
+        assert.throws(function() { new mapnik.Datasource({ type:'geojson', inline: fs.readFileSync('./test/data/parse.error.json').toString(), cache_features: false }); });
+    });
+
+    it('test empty geojson datasource due to invalid json file', function() {
+        var ds = new mapnik.Datasource({ type:'geojson', file: './test/data/parse.error.json', cache_features: false });
+        var empty_fs = ds.featureset();
+        assert.equal(typeof(empty_fs),'undefined');
+        assert.equal(empty_fs, null);
+    });
+
     it('test valid use of memory datasource', function() {
         var ds = new mapnik.MemoryDatasource({'extent': '-180,-90,180,90'});
         assert.equal(true, ds.add({ 'x': 0, 'y': 0 }));

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -217,7 +217,7 @@ describe('mapnik.Feature ', function() {
     it('should be able to get a featureset from Memory datasource', function() {
         var mem_datasource = new mapnik.MemoryDatasource({'extent': '-180,-90,180,90'});
         var fs0 = mem_datasource.featureset();
-        assert.equal(undefined, fs0.next());
+        assert.equal(undefined, fs0);
         mem_datasource.add({ 'x': 0, 'y': 0 });
         var fs1 = mem_datasource.featureset();
         assert.equal('{"type":"Feature","id":1,"geometry":{"type":"Point","coordinates":[0,0]},"properties":{}}',


### PR DESCRIPTION
We want to consistently make `ds.featureset()` return `undefined` if a featureset is empty. This is how node-mapnik has worked for a while, but this upstream change (https://github.com/mapnik/mapnik/commit/75781a999c33afb0d54041a1208d3cc475dec8e4) altered the behavior temporarily: it meant that empty featuresets would come through as valid JS Featureset objects and you would need to call `fs.next()` to see if they were empty.

This PR keeps back compatibility and add tests for this behavior.
