### PR TITLE
add crs to addGeoJSON docs

### DIFF
--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -3148,7 +3148,8 @@ void VectorTile::after_to_geojson(uv_work_t* req)
 }
 
 /**
- * Add features to this tile from a GeoJSON string
+ * Add features to this tile from a GeoJSON string. GeoJSON coordinates must be in the WGS84 longitude & latitude CRS
+ * as specified in the [GeoJSON Specification](https://www.rfc-editor.org/rfc/rfc7946.txt).
  *
  * @memberof VectorTile
  * @instance


### PR DESCRIPTION
Just a quick explicit addition to the `mapnik.VectorTile.addGeoJSON()` method that states the incoming GeoJSON datasource must be in WGS84 lat/lng.

refs #693 which would have benefited from improved docs