### PR TITLE
Limit image size in image.fromSVG and image.fromSVGBytes

### DIFF
--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -2520,6 +2520,9 @@ void Image::EIO_AfterOpen(uv_work_t* req)
  * @param {Object} [options]
  * @param {number} [options.scale] - scale the image. For example passing `0.5` as scale would render
  * your SVG at 50% the original size.
+ * @param {number} [options.max_size] - the maximum allowed size of the svg dimensions * scale. The default is 2048.
+ * This option can be passed a smaller or larger size in order to control the final size of the image allocated for
+ * rasterizing the SVG.
  * @returns {mapnik.Image} Image object
  * @example
  * var buffer = fs.readFileSync('./path/to/image.svg');
@@ -2538,6 +2541,9 @@ NAN_METHOD(Image::fromSVGBytesSync)
  * @param {Object} [options]
  * @param {number} [options.scale] - scale the image. For example passing `0.5` as scale would render
  * your SVG at 50% the original size.
+ * @param {number} [options.max_size] - the maximum allowed size of the svg dimensions * scale. The default is 2048.
+ * This option can be passed a smaller or larger size in order to control the final size of the image allocated for
+ * rasterizing the SVG.
  * @returns {mapnik.Image} image object
  * @static
  * @memberof Image
@@ -2753,6 +2759,9 @@ typedef struct {
  * @param {Object} [options]
  * @param {number} [options.scale] - scale the image. For example passing `0.5` as scale would render
  * your SVG at 50% the original size.
+ * @param {number} [options.max_size] - the maximum allowed size of the svg dimensions * scale. The default is 2048.
+ * This option can be passed a smaller or larger size in order to control the final size of the image allocated for
+ * rasterizing the SVG.
  * @param {Function} callback
  * @static
  * @memberof Image
@@ -2957,6 +2966,9 @@ void Image::EIO_AfterFromSVG(uv_work_t* req)
  * @param {Object} [options]
  * @param {number} [options.scale] - scale the image. For example passing `0.5` as scale would render
  * your SVG at 50% the original size.
+ * @param {number} [options.max_size] - the maximum allowed size of the svg dimensions * scale. The default is 2048.
+ * This option can be passed a smaller or larger size in order to control the final size of the image allocated for
+ * rasterizing the SVG.
  * @param {Function} callback = `function(err, img)`
  * @example
  * var buffer = fs.readFileSync('./path/to/image.svg');

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -2567,6 +2567,7 @@ v8::Local<v8::Value> Image::_fromSVGSync(bool fromFile, Nan::NAN_METHOD_ARGS_TYP
 
 
     double scale = 1.0;
+    std::uint32_t max_size = 2048;
     if (info.Length() >= 2) 
     {
         if (!info[1]->IsObject()) 
@@ -2589,6 +2590,21 @@ v8::Local<v8::Value> Image::_fromSVGSync(bool fromFile, Nan::NAN_METHOD_ARGS_TYP
                 Nan::ThrowTypeError("'scale' must be a positive non zero number");
                 return scope.Escape(Nan::Undefined());
             }
+        }
+        if (options->Has(Nan::New("max_size").ToLocalChecked()))
+        {
+            v8::Local<v8::Value> opt = options->Get(Nan::New("max_size").ToLocalChecked());
+            if (!opt->IsNumber())
+            {
+                Nan::ThrowTypeError("max_size must be a positive integer");
+                return scope.Escape(Nan::Undefined());
+            }
+            auto max_size_val = opt->IntegerValue();
+            if (max_size_val < 0 || max_size_val > 65535) {
+                Nan::ThrowTypeError("max_size must be a positive integer between 0 and 65535");
+                return scope.Escape(Nan::Undefined());
+            }
+            max_size = static_cast<std::uint32_t>(max_size_val);
         }
     }
 
@@ -2657,6 +2673,14 @@ v8::Local<v8::Value> Image::_fromSVGSync(bool fromFile, Nan::NAN_METHOD_ARGS_TYP
             return scope.Escape(Nan::Undefined());
         }
 
+        if (svg_width > static_cast<int>(max_size) || svg_height > static_cast<int>(max_size))
+        {
+            std::stringstream s;
+            s << "image created from svg must be " << max_size << " pixels or fewer on each side";
+            Nan::ThrowTypeError(s.str().c_str());
+            return scope.Escape(Nan::Undefined());
+        }
+
         mapnik::image_rgba8 im(svg_width, svg_height, true, true);
         agg::rendering_buffer buf(im.bytes(), im.width(), im.height(), im.row_size());
         pixfmt pixf(buf);
@@ -2703,6 +2727,7 @@ typedef struct {
     std::string filename;
     bool error;
     double scale;
+    std::uint32_t max_size;
     std::string error_name;
     Nan::Persistent<v8::Function> cb;
 } svg_file_ptr_baton_t;
@@ -2714,6 +2739,7 @@ typedef struct {
     size_t dataLength;
     bool error;
     double scale;
+    std::uint32_t max_size;
     std::string error_name;
     Nan::Persistent<v8::Object> buffer;
     Nan::Persistent<v8::Function> cb;
@@ -2757,6 +2783,7 @@ NAN_METHOD(Image::fromSVG)
     }
 
     double scale = 1.0;
+    std::uint32_t max_size = 2048;
     if (info.Length() >= 3) 
     {
         if (!info[1]->IsObject()) 
@@ -2780,6 +2807,21 @@ NAN_METHOD(Image::fromSVG)
                 return;
             }
         }
+        if (options->Has(Nan::New("max_size").ToLocalChecked()))
+        {
+            v8::Local<v8::Value> opt = options->Get(Nan::New("max_size").ToLocalChecked());
+            if (!opt->IsNumber())
+            {
+                Nan::ThrowTypeError("max_size must be a positive integer");
+                return;
+            }
+            auto max_size_val = opt->IntegerValue();
+            if (max_size_val < 0 || max_size_val > 65535) {
+                Nan::ThrowTypeError("max_size must be a positive integer between 0 and 65535");
+                return;
+            }
+            max_size = static_cast<std::uint32_t>(max_size_val);
+        }
     }
 
     svg_file_ptr_baton_t *closure = new svg_file_ptr_baton_t();
@@ -2787,6 +2829,7 @@ NAN_METHOD(Image::fromSVG)
     closure->filename = TOSTR(info[0]);
     closure->error = false;
     closure->scale = scale;
+    closure->max_size = max_size;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_FromSVG, (uv_after_work_cb)EIO_AfterFromSVG);
     return;
@@ -2836,6 +2879,15 @@ void Image::EIO_FromSVG(uv_work_t* req)
         {
             closure->error = true;
             closure->error_name = "image created from svg must have a width and height greater then zero";
+            return;
+        }
+
+        if (svg_width > static_cast<int>(closure->max_size) || svg_height > static_cast<int>(closure->max_size))
+        {
+            closure->error = true;
+            std::stringstream s;
+            s << "image created from svg must be " << closure->max_size << " pixels or fewer on each side";
+            closure->error_name = s.str();
             return;
         }
 
@@ -2939,6 +2991,7 @@ NAN_METHOD(Image::fromSVGBytes)
     }
 
     double scale = 1.0;
+    std::uint32_t max_size = 2048;
     if (info.Length() >= 3) 
     {
         if (!info[1]->IsObject()) 
@@ -2962,6 +3015,21 @@ NAN_METHOD(Image::fromSVGBytes)
                 return;
             }
         }
+        if (options->Has(Nan::New("max_size").ToLocalChecked()))
+        {
+            v8::Local<v8::Value> opt = options->Get(Nan::New("max_size").ToLocalChecked());
+            if (!opt->IsNumber())
+            {
+                Nan::ThrowTypeError("max_size must be a positive integer");
+                return;
+            }
+            auto max_size_val = opt->IntegerValue();
+            if (max_size_val < 0 || max_size_val > 65535) {
+                Nan::ThrowTypeError("max_size must be a positive integer between 0 and 65535");
+                return;
+            }
+            max_size = static_cast<std::uint32_t>(max_size_val);
+        }
     }
 
     svg_mem_ptr_baton_t *closure = new svg_mem_ptr_baton_t();
@@ -2971,6 +3039,7 @@ NAN_METHOD(Image::fromSVGBytes)
     closure->buffer.Reset(obj.As<v8::Object>());
     closure->data = node::Buffer::Data(obj);
     closure->scale = scale;
+    closure->max_size = max_size;
     closure->dataLength = node::Buffer::Length(obj);
     uv_queue_work(uv_default_loop(), &closure->request, EIO_FromSVGBytes, (uv_after_work_cb)EIO_AfterFromSVGBytes);
     return;
@@ -3022,6 +3091,15 @@ void Image::EIO_FromSVGBytes(uv_work_t* req)
         {
             closure->error = true;
             closure->error_name = "image created from svg must have a width and height greater then zero";
+            return;
+        }
+
+        if (svg_width > static_cast<int>(closure->max_size) || svg_height > static_cast<int>(closure->max_size))
+        {
+            closure->error = true;
+            std::stringstream s;
+            s << "image created from svg must be " << closure->max_size << " pixels or fewer on each side";
+            closure->error_name = s.str();
             return;
         }
 

--- a/test/image.svg.test.js
+++ b/test/image.svg.test.js
@@ -91,16 +91,21 @@ describe('mapnik.Image SVG', function() {
 
     });
 
-    it('blocks allocating a very large image', function(done) {
-        // 65535 is the max width/height in mapnik
-        var svgdata = "<svg width='65535' height='65535'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
-        mapnik.Image.fromSVGBytes(buffer, function(err, img) {
-            assert.ok(err);
-            assert.ok(err.message.match(/image created from svg must be 2048 pixels or fewer on each side/));
-            done();
+    if (process.platform === 'win32') {
+        // skip on windows since appveyor does not have enough memory
+        it.skip('blocks allocating a very large image', function(done) {});
+    } else {
+        it('blocks allocating a very large image', function(done) {
+            // 65535 is the max width/height in mapnik
+            var svgdata = "<svg width='65535' height='65535'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
+            var buffer = new Buffer(svgdata);
+            mapnik.Image.fromSVGBytes(buffer, function(err, img) {
+                assert.ok(err);
+                assert.ok(err.message.match(/image created from svg must be 2048 pixels or fewer on each side/));
+                done();
+            });
         });
-    });
+    }
 
 
     it('customized the max image size to block', function(done) {

--- a/test/image.svg.test.js
+++ b/test/image.svg.test.js
@@ -91,22 +91,16 @@ describe('mapnik.Image SVG', function() {
 
     });
 
-    if (process.platform === 'win32') {
-        // skip on windows since appveyor does not have enough memory
-        it.skip('blocks allocating a very large image', function(done) {});
-    } else {
-        it('blocks allocating a very large image', function(done) {
-            // 65535 is the max width/height in mapnik
-            var svgdata = "<svg width='65535' height='65535'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-            var buffer = new Buffer(svgdata);
-            mapnik.Image.fromSVGBytes(buffer, function(err, img) {
-                assert.ok(err);
-                assert.ok(err.message.match(/image created from svg must be 2048 pixels or fewer on each side/));
-                done();
-            });
+    it('blocks allocating a very large image', function(done) {
+        // 65535 is the max width/height in mapnik
+        var svgdata = "<svg width='65535' height='65535'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
+        var buffer = new Buffer(svgdata);
+        mapnik.Image.fromSVGBytes(buffer, function(err, img) {
+            assert.ok(err);
+            assert.ok(err.message.match(/image created from svg must be 2048 pixels or fewer on each side/));
+            done();
         });
-    }
-
+    });
 
     it('customized the max image size to block', function(done) {
         // 65535 is the max width/height in mapnik
@@ -130,17 +124,22 @@ describe('mapnik.Image SVG', function() {
         });
     });
 
-    it('allocates very large image', function(done) {
-        // 65535 is the max width/height in mapnik
-        var svgdata = "<svg width='5000' height='5000'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
-        var buffer = new Buffer(svgdata);
-        mapnik.Image.fromSVGBytes(buffer, {scale: 2, max_size:10000}, function(err, img) {
-            if (err) throw err;
-            assert.equal(img.width(),10000);
-            assert.equal(img.height(),10000);
-            done();
+    if (process.platform === 'win32') {
+        // skip on windows since appveyor does not have enough memory
+        it('allocates very large image', function(done) {});
+    } else {
+        it('allocates very large image', function(done) {
+            // 65535 is the max width/height in mapnik
+            var svgdata = "<svg width='5000' height='5000'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
+            var buffer = new Buffer(svgdata);
+            mapnik.Image.fromSVGBytes(buffer, {scale: 2, max_size:10000}, function(err, img) {
+                if (err) throw err;
+                assert.equal(img.width(),10000);
+                assert.equal(img.height(),10000);
+                done();
+            });
         });
-    });
+    }
 
     it('should err with async file w/o width or height', function(done) {
       mapnik.Image.fromSVG('./test/data/vector_tile/tile0.corrupt-svg.svg', function(err, svg) {

--- a/test/image.svg.test.js
+++ b/test/image.svg.test.js
@@ -83,12 +83,58 @@ describe('mapnik.Image SVG', function() {
                 var buffer2 = new Buffer(svgdata2);
                 mapnik.Image.fromSVGBytes(buffer2, { scale: 1000000 }, function(err, img) {
                     assert.ok(err);
-                    assert.ok(err.message.match(/Invalid width for image dimensions requested/));
+                    assert.ok(err.message.match(/image created from svg must be 2048 pixels or fewer on each side/));
                     done();
                 });
             });
         });
 
+    });
+
+    it('blocks allocating a very large image', function(done) {
+        // 65535 is the max width/height in mapnik
+        var svgdata = "<svg width='65535' height='65535'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
+        var buffer = new Buffer(svgdata);
+        mapnik.Image.fromSVGBytes(buffer, function(err, img) {
+            assert.ok(err);
+            assert.ok(err.message.match(/image created from svg must be 2048 pixels or fewer on each side/));
+            done();
+        });
+    });
+
+
+    it('customized the max image size to block', function(done) {
+        // 65535 is the max width/height in mapnik
+        var svgdata = "<svg width='65535' height='65535'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
+        var buffer = new Buffer(svgdata);
+        mapnik.Image.fromSVGBytes(buffer, {max_size:2049}, function(err, img) {
+            assert.ok(err);
+            assert.ok(err.message.match(/image created from svg must be 2049 pixels or fewer on each side/));
+            done();
+        });
+    });
+
+    it('max image size blocks dimension*scale', function(done) {
+        // 65535 is the max width/height in mapnik
+        var svgdata = "<svg width='5000' height='5000'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
+        var buffer = new Buffer(svgdata);
+        mapnik.Image.fromSVGBytes(buffer, {scale: 2, max_size:10000-1}, function(err, img) {
+            assert.ok(err);
+            assert.ok(err.message.match(/image created from svg must be 9999 pixels or fewer on each side/));
+            done();
+        });
+    });
+
+    it('allocates very large image', function(done) {
+        // 65535 is the max width/height in mapnik
+        var svgdata = "<svg width='5000' height='5000'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
+        var buffer = new Buffer(svgdata);
+        mapnik.Image.fromSVGBytes(buffer, {scale: 2, max_size:10000}, function(err, img) {
+            if (err) throw err;
+            assert.equal(img.width(),10000);
+            assert.equal(img.height(),10000);
+            done();
+        });
     });
 
     it('should err with async file w/o width or height', function(done) {

--- a/test/image.svg.test.js
+++ b/test/image.svg.test.js
@@ -126,7 +126,7 @@ describe('mapnik.Image SVG', function() {
 
     if (process.platform === 'win32') {
         // skip on windows since appveyor does not have enough memory
-        it('allocates very large image', function(done) {});
+        it.skip('allocates very large image', function() {});
     } else {
         it('allocates very large image', function(done) {
             // 65535 is the max width/height in mapnik


### PR DESCRIPTION
Currently it is possible for `image.fromSVG` or `image.fromSVGBytes` to allocate an unreasonably large image internally for rasterizing (which would likely lead to an OOM killer on linux). To allow programs to limit this size before this internal image is allocated there is now:

  - A default max size of an SVG 2046x2046
  - A new `max_size` option that can be passed to change this default value.

Addresses #708

/cc @mapsam @jakepruitt for code review (if either of you have time)

/cc @scothis @tmcw to keep apprised of work