### PR TITLE
Add max_size limitation + premultiply option to fromBytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,8 @@ before_install:
  - if [[ $(uname -s) == 'Linux' ]] && [[ ${CXX:-"notset"} == "notset" ]]; then
      git clone --depth 1 https://github.com/mapbox/mason.git ./.mason;
      export PATH=$(pwd)/.mason:${PATH};
-     mason install clang 3.9.1;
-     export PATH=$(mason prefix clang 3.9.1)/bin:${PATH};
+     mason install clang++ 3.9.1;
+     export PATH=$(mason prefix clang++ 3.9.1)/bin:${PATH};
      export CXX=clang++-3.9;
      export CC=clang-3.9;
      export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python2.7/site-packages;

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,10 +94,10 @@ before_install:
  - if [[ $(uname -s) == 'Linux' ]] && [[ ${CXX:-"notset"} == "notset" ]]; then
      git clone --depth 1 https://github.com/mapbox/mason.git ./.mason;
      export PATH=$(pwd)/.mason:${PATH};
-     mason install clang 3.8.0;
-     export PATH=$(mason prefix clang 3.8.0)/bin:${PATH};
-     export CXX=clang++-3.8;
-     export CC=clang-3.8;
+     mason install clang 3.9.1;
+     export PATH=$(mason prefix clang 3.9.1)/bin:${PATH};
+     export CXX=clang++-3.9;
+     export CC=clang-3.9;
      export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python2.7/site-packages;
    else
      export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python/site-packages;

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -92,22 +92,24 @@ describe('mapnik.Image ', function() {
     });
 
     it('should throw with invalid binary read from buffer', function(done) {
-        assert.throws(function() { new mapnik.Image.fromBytesSync(); });
-        assert.throws(function() { new mapnik.Image.fromBytes(); });
-        assert.throws(function() { new mapnik.Image.fromBytes(null); });
-        assert.throws(function() { new mapnik.Image.fromBytes(null, function(err, result) {}); });
-        assert.throws(function() { new mapnik.Image.fromBytes({}); });
-        assert.throws(function() { new mapnik.Image.fromBytes({}, function(err, result) {}); });
-        assert.throws(function() { new mapnik.Image.fromBytesSync({}); });
-        assert.throws(function() { new mapnik.Image.fromBytes(new Buffer(0)); });
-        assert.throws(function() { new mapnik.Image.fromBytes(new Buffer(0), null); });
-        assert.throws(function() { new mapnik.Image.fromBytesSync(new Buffer(1024)); });
+        assert.throws(function() { mapnik.Image.fromBytesSync(); });
+        assert.throws(function() { mapnik.Image.fromBytes(); });
+        assert.throws(function() { mapnik.Image.fromBytes(null); });
+        assert.throws(function() { mapnik.Image.fromBytes(null, function(err, result) {}); });
+        assert.throws(function() { mapnik.Image.fromBytes({}); });
+        assert.throws(function() { mapnik.Image.fromBytes({}, function(err, result) {}); });
+        assert.throws(function() { mapnik.Image.fromBytesSync({}); });
+        assert.throws(function() { mapnik.Image.fromBytes(new Buffer(0)); });
+        assert.throws(function() { mapnik.Image.fromBytes(new Buffer(0),{premultiply:1},function(){}); });
+        assert.throws(function() { mapnik.Image.fromBytes(new Buffer(0), null); });
+        assert.throws(function() { mapnik.Image.fromBytesSync(new Buffer(1024)); });
         var buffer = new Buffer('\x89\x50\x4E\x47\x0D\x0A\x1A\x0A' + new Array(48).join('\0'), 'binary');
-        assert.throws(function() { new mapnik.Image.fromBytesSync(buffer); });
+        assert.throws(function() { mapnik.Image.fromBytesSync(buffer); });
         buffer = new Buffer('\x89\x50\x4E\x47\x0D\x0A\x1A\x0A', 'binary');
-        assert.throws(function() { new mapnik.Image.fromBytesSync(buffer); });
-        var stuff = new mapnik.Image.fromBytes(buffer, function(err, result) {
+        assert.throws(function() { mapnik.Image.fromBytesSync(buffer); });
+        var stuff = mapnik.Image.fromBytes(buffer, function(err, result) {
             assert.throws(function() { if (err) throw err; });
+
             done();
         });
     });
@@ -1574,6 +1576,20 @@ describe('mapnik.Image ', function() {
         assert.throws(function() { var im = new mapnik.Image.fromBufferSync(2, 2, b, {'type':null}); });
         assert.throws(function() { var im = new mapnik.Image.fromBufferSync(2, 2, b, {'premultiplied':null}); });
         assert.throws(function() { var im = new mapnik.Image.fromBufferSync(2, 2, b, {'painted':null}); });
+    });
+
+    it('fromBytes can premultiply in async/threadpool', function(done) {
+        var data = require('fs').readFileSync(__dirname + '/support/a.png');
+        var image = mapnik.Image.fromBytesSync(data);
+        mapnik.Image.fromBytes(data, {premultiply:false}, function(err, im) {
+            if (err) throw err;
+            assert.ok(!im.premultiplied());
+            mapnik.Image.fromBytes(data, {premultiply:true}, function(err, im) {
+                if (err) throw err;
+                assert.ok(im.premultiplied());
+                done();
+            });
+        });
     });
 
     it('resizes consistently', function(done) {

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -1580,7 +1580,6 @@ describe('mapnik.Image ', function() {
 
     it('fromBytes can premultiply in async/threadpool', function(done) {
         var data = require('fs').readFileSync(__dirname + '/support/a.png');
-        var image = mapnik.Image.fromBytesSync(data);
         mapnik.Image.fromBytes(data, {premultiply:false}, function(err, im) {
             if (err) throw err;
             assert.ok(!im.premultiplied());
@@ -1589,6 +1588,16 @@ describe('mapnik.Image ', function() {
                 assert.ok(im.premultiplied());
                 done();
             });
+        });
+    });
+
+    it('fromBytes can limit max image size', function(done) {
+        var data = require('fs').readFileSync(__dirname + '/support/a.png');
+        mapnik.Image.fromBytes(data, {max_size:10, premultiply:false}, function(err, im) {
+            assert.ok(!im);
+            assert.ok(err);
+            assert.ok(err.message == 'image created from bytes must be 10 pixels or fewer on each side');
+            done();
         });
     });
 


### PR DESCRIPTION
This extends the `mapnik.Image.fromBytes` function to have more options for top performance:

  - Now accepts a `premultiply:true` option that can be passed to premultiply during the byte conversion. This allows calling applications to avoid needing to premultiply in a separate step (saving on needing to enter and exit the threadpool again, which can cause contention under high load or when the threadpool is full of work)
  - Adds a max_size constraint to ensure that an unreasonably large image is not allocated.