### PR TITLE
Parsing empty GeoJSON from file now throws

### DIFF
--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -213,10 +213,7 @@ describe('mapnik.Datasource', function() {
     });
 
     it('test empty geojson datasource due to invalid json file', function() {
-        var ds = new mapnik.Datasource({ type:'geojson', file: './test/data/parse.error.json', cache_features: false });
-        var empty_fs = ds.featureset();
-        assert.equal(typeof(empty_fs),'undefined');
-        assert.equal(empty_fs, null);
+        assert.throws(function() { new mapnik.Datasource({ type:'geojson', file: './test/data/parse.error.json', cache_features: false }); });
     });
 
     it('test valid use of memory datasource', function() {


### PR DESCRIPTION
When built against mapnik 3.0.13 the test for parsing empty geojson from a file is now throwing:

```
  1) mapnik.Datasource test empty geojson datasource due to invalid json file:
     Error: Failed to parse geojson feature
      at Error (native)
      at Context.<anonymous> (test/datasource.test.js:215:18)
```

This seems to be consistent with the behaviour of the previous test (parsing empty geojson from a string) so I'm guessing something was deliberately changed in mapnik to make this consistent?

Not sure if you'll want to take this simple patch as is, or something more complicated that allows for either behaviour...