### PR TITLE
Fix windows after masonization of unix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ node_modules: mason_packages/.link/bin/mapnik-config
 	npm install --ignore-scripts --clang
 
 release: node_modules
-	V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
+	PATH="./mason_packages/.link/bin/:${PATH}" && V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
 	@echo "run 'make clean' for full rebuild"
 
 debug: node_modules
-	V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --debug --clang
+	PATH="./mason_packages/.link/bin/:${PATH}" && V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --debug --clang
 	@echo "run 'make clean' for full rebuild"
 
 coverage:

--- a/binding.gyp
+++ b/binding.gyp
@@ -64,7 +64,7 @@
         "<!(node -e \"require('mapnik-vector-tile')\")"
       ],
       'defines': [
-          'MAPNIK_GIT_REVISION="<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --git-describe)"',
+          'MAPNIK_GIT_REVISION="<!@(mapnik-config --git-describe)"',
           'CLIPPER_INTPOINT_IMPL=mapnik::geometry::point<cInt>',
           'CLIPPER_PATH_IMPL=mapnik::geometry::line_string<cInt>',
           'CLIPPER_PATHS_IMPL=mapnik::geometry::multi_line_string<cInt>',
@@ -74,22 +74,22 @@
         ['OS=="win"',
           {
             'include_dirs':[
-              '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --includes)',
-              '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --dep-includes)'
+              '<!@(mapnik-config --includes)',
+              '<!@(mapnik-config --dep-includes)'
             ],
-            'defines': ['NOMINMAX','<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --defines)'],
+            'defines': ['NOMINMAX','<!@(mapnik-config --defines)'],
             'defines!': ["_HAS_EXCEPTIONS=0"],
             'libraries': [
-              '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --libs)',
+              '<!@(mapnik-config --libs)',
               'mapnik-wkt.lib',
               'mapnik-json.lib',
-              '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --dep-libs)',
+              '<!@(mapnik-config --dep-libs)',
             ],
             'msvs_disabled_warnings': [ 4244,4005,4506,4345,4804,4805 ],
             'msvs_settings': {
               'VCLinkerTool': {
                 'AdditionalLibraryDirectories': [
-                  '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --ldflags)'
+                  '<!@(mapnik-config --ldflags)'
                 ],
               },
             }
@@ -97,15 +97,15 @@
           {
             'cflags_cc!': ['-fno-rtti', '-fno-exceptions'],
             'cflags_cc' : [
-              '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --cflags)',
+              '<!@(mapnik-config --cflags)',
               '-D_GLIBCXX_USE_CXX11_ABI=0'
             ],
             'libraries':[
-              '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --libs)',
+              '<!@(mapnik-config --libs)',
               '-lmapnik-wkt',
               '-lmapnik-json',
-              '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --ldflags)',
-              '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --dep-libs)'
+              '<!@(mapnik-config --ldflags)',
+              '<!@(mapnik-config --dep-libs)'
             ],
             'ldflags': [
               '-Wl,-z,now',
@@ -114,10 +114,10 @@
             ],
             'xcode_settings': {
               'OTHER_CPLUSPLUSFLAGS':[
-                '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --cflags)',
+                '<!@(mapnik-config --cflags)',
               ],
               'OTHER_CFLAGS':[
-                '<!@(<(module_root_dir)/mason_packages/.link/bin/mapnik-config --cflags)'
+                '<!@(mapnik-config --cflags)'
               ],
               'OTHER_LDFLAGS':[
                 '-Wl,-bind_at_load'

--- a/binding.gyp
+++ b/binding.gyp
@@ -61,6 +61,9 @@
         './mason_packages/.link/include/cairo',
         './src',
         "<!(node -e \"require('nan')\")",
+        # TODO: move these to mason packages once we have a minimal windows client for mason (@springmeyer)
+        # https://github.com/mapbox/mason/issues/396
+        "<!(node -e \"require('protozero')\")",
         "<!(node -e \"require('mapnik-vector-tile')\")"
       ],
       'defines': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -141,13 +141,19 @@
       'type': 'none',
       'dependencies': [ '<(module_name)' ],
       'hard_dependency': 1,
-      'actions': [
-        {
-          'action_name': 'postinstall',
-          'inputs': ['./scripts/postinstall.sh'],
-          'outputs': ['./lib/binding/mapnik'],
-          'action': ['./scripts/postinstall.sh']
-        }
+      'conditions': [
+        ['OS!="win"',
+          {
+            'actions': [
+              {
+                'action_name': 'postinstall',
+                'inputs': ['./scripts/postinstall.sh'],
+                'outputs': ['./lib/binding/mapnik'],
+                'action': ['./scripts/postinstall.sh']
+              }
+            ]
+          }
+        ]
       ]
     },
   ]

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -35,5 +35,8 @@ if [ ! -f ./mason_packages/.link/bin/mapnik-config ]; then
     install harfbuzz 1.4.2-ft
 
     # mapnik
+    # NOTE: sync this version with the `mapnik_version` in package.json (which is used for windows builds)
+    # In the future we could pull from that version automatically if mason were to support knowing the right dep
+    # versions to install automatically. Until then there is not much point since the deps are still hardcoded here.
     install mapnik 3.0.13
 fi

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -36,7 +36,4 @@ if [ ! -f ./mason_packages/.link/bin/mapnik-config ]; then
 
     # mapnik
     install mapnik 3.0.13
-
-    # node-mapnik deps
-    install protozero 1.5.1
 fi

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://mapnik.org",
   "author": "Dane Springmeyer <dane@mapbox.com> (mapnik.org)",
   "version": "3.5.14-testpublish",
-  "mapnik_version":"v3.0.12",
+  "mapnik_version":"v3.0.13",
   "main": "./lib/mapnik.js",
   "binary": {
     "module_name": "mapnik",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "mapnik-vector-tile": "~1.2.2",
     "nan": "~2.5.0",
+    "protozero": "~1.5.1",
     "node-pre-gyp": "~0.6.30"
   },
   "bundledDependencies": [


### PR DESCRIPTION
#738 ported the unix build system to use mason packages for dependencies (mapnik included). However mason does not support windows, so this rolls back some changes to keep the build working on windows.

/cc @BergWerkGIS for review.

Fixes #744