### PR TITLE
Fix packaging of portable data for icu, gdal, and proj

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ install:
   - clang++ -v
   - which clang++
   - make ${BUILDTYPE}
+  # Build should be standalone now, so remove mason deps
+  - rm -rf mason_packages
 
 # run tests
 # we use before_script rather than script to ensure fast failure (the script section continues even after an error)

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -6,20 +6,20 @@ MODULE_PATH=./lib/binding
 MAPNIK_SDK=./mason_packages/.link
 
 mkdir -p ${MODULE_PATH}/bin/
-cp -L ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
+cp ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
 # copy shapeindex
-cp -L ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
+cp ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
 # copy lib
 mkdir -p ${MODULE_PATH}/lib/
-cp -L ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
+cp ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
 # copy plugins
-cp -rL ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
+cp -r ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
 # copy share data
 mkdir -p ${MODULE_PATH}/share/gdal
-cp -rL ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
-cp -rL ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
+cp -L ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
+cp -r ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
 mkdir -p ${MODULE_PATH}/share/icu
-cp -rL ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
+cp -L ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
 
 # generate new settings
 echo "

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -6,20 +6,20 @@ MODULE_PATH=./lib/binding
 MAPNIK_SDK=./mason_packages/.link
 
 mkdir -p ${MODULE_PATH}/bin/
-cp ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
+cp -L ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
 # copy shapeindex
-cp ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
+cp -L ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
 # copy lib
 mkdir -p ${MODULE_PATH}/lib/
-cp ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
+cp -L ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
 # copy plugins
-cp -r ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
+cp -rL ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
 # copy share data
 mkdir -p ${MODULE_PATH}/share/gdal
-cp -r ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
-cp -r ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
+cp -rL ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
+cp -rL ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
 mkdir -p ${MODULE_PATH}/share/icu
-cp -r ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
+cp -rL ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
 
 # generate new settings
 echo "

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -6,20 +6,43 @@ MODULE_PATH=./lib/binding
 MAPNIK_SDK=./mason_packages/.link
 
 mkdir -p ${MODULE_PATH}/bin/
-cp ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
-# copy shapeindex
-cp ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
-# copy lib
-mkdir -p ${MODULE_PATH}/lib/
-cp ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
-# copy plugins
-cp -r ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
-# copy share data
-mkdir -p ${MODULE_PATH}/share/gdal
-cp -L ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
-cp -r ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
-mkdir -p ${MODULE_PATH}/share/icu
-cp -L ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
+
+# the below switch is used since on osx the default cp
+# resolves symlinks automatically with `cp -r`
+# whereas on linux we need to pass `cp -rL`. But the latter
+# command is not supported on OS X. We could upgrade coreutils
+# but ideally we don't depend on more dependencies
+if [[ $(uname -s) == 'Darwin' ]]; then
+    cp ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
+    # copy shapeindex
+    cp ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
+    # copy lib
+    mkdir -p ${MODULE_PATH}/lib/
+    cp ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
+    # copy plugins
+    cp -r ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
+    # copy share data
+    mkdir -p ${MODULE_PATH}/share/gdal
+    cp -L ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
+    cp -r ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
+    mkdir -p ${MODULE_PATH}/share/icu
+    cp -L ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
+else
+    cp -L ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
+    # copy shapeindex
+    cp -L ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
+    # copy lib
+    mkdir -p ${MODULE_PATH}/lib/
+    cp -L ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
+    # copy plugins
+    cp -rL ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
+    # copy share data
+    mkdir -p ${MODULE_PATH}/share/gdal
+    cp -rL ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
+    cp -rL ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
+    mkdir -p ${MODULE_PATH}/share/icu
+    cp -rL ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
+fi
 
 # generate new settings
 echo "


### PR DESCRIPTION
### Context

We moved to using [mason](https://github.com/mapbox/mason/) for dependencies in #738. Mason supports the `mason link` command which places symlinks of files at predictable paths. The build then copies these over into `lib/binding` when packaging the portable node-mapnik binaries.

### The bug

The symlinks were being copied rather than the actual files. This meant that, once published, the data was missing since the symlinks were "broken" (point to non existent data).

### Solution

We need to ensure this bug never happens. So this PR moves to removing the `mason_packages` folder before running the node-mapnik tests. This replicates the `point to non existent data` situation during node-mapnik travis builds.

This PR also starts passing the `-L` flag to `cp` to deference the symlinks during copy to ensure we are copying the full data and not just the symlink.