### PR TITLE
[WIP] profiling builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,10 @@ matrix:
         - chmod +x codecov
         - ./codecov -x "llvm-cov gcov" -Z
 
+# show binary size
+after_success:
+ - ls -lh $(./node_modules/.bin/node-pre-gyp --silent reveal module)
+
 notifications:
   slack:
     secure: wLpScQaDoEsVe0Bu28b62FGZBfmX3s/NK8DWcuSxEFx80k8RKPNgnMg8htamG0zRSf5htF+X6jy2P0IeUvbeupIaJwqtXvHaJYtlMTmemG/xuXLTpLp6k6giT2mWm/lp+ykuaF/PvUcZWUhSf1zhS6vwIekrMYIcDYvNXjO8DNw=

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,15 @@ node_modules: mason_packages/.link/bin/mapnik-config
 	npm install --ignore-scripts --clang
 
 # NOTE: `-fno-omit-frame-pointer -gline-tables-only` are added per https://github.com/mapbox/cpp/blob/master/glossary.md#profiling-build
+
+ifneq (,$(findstring clang,$(CXX)))
+    PROFILING_FLAG += -gline-tables-only
+else
+    PROFILING_FLAG += -g
+endif
+
 release: node_modules
-	CXXFLAGS="-fno-omit-frame-pointer -gline-tables-only" PATH="./mason_packages/.link/bin/:${PATH}" V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
+	CXXFLAGS="-fno-omit-frame-pointer $(PROFILING_FLAG)" PATH="./mason_packages/.link/bin/:${PATH}" V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
 	@echo "run 'make clean' for full rebuild"
 
 debug: node_modules

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ clean:
 distclean: clean
 	rm -rf node_modules
 	rm -rf mason_packages
+	rm -rf ./.mason
+	rm -rf ./mason
 
 xcode: node_modules
 	./node_modules/.bin/node-pre-gyp configure -- -f xcode

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,13 @@ node_modules: mason_packages/.link/bin/mapnik-config
 	# so that we can run it directly in either debug or release
 	npm install --ignore-scripts --clang
 
+# NOTE: `-fno-omit-frame-pointer -gline-tables-only` are added per https://github.com/mapbox/cpp/blob/master/glossary.md#profiling-build
 release: node_modules
-	PATH="./mason_packages/.link/bin/:${PATH}" && V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
+	CXXFLAGS="-fno-omit-frame-pointer -gline-tables-only" PATH="./mason_packages/.link/bin/:${PATH}" V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
 	@echo "run 'make clean' for full rebuild"
 
 debug: node_modules
-	PATH="./mason_packages/.link/bin/:${PATH}" && V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --debug --clang
+	PATH="./mason_packages/.link/bin/:${PATH}" V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --debug --clang
 	@echo "run 'make clean' for full rebuild"
 
 coverage:

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -38,5 +38,5 @@ if [ ! -f ./mason_packages/.link/bin/mapnik-config ]; then
     # NOTE: sync this version with the `mapnik_version` in package.json (which is used for windows builds)
     # In the future we could pull from that version automatically if mason were to support knowing the right dep
     # versions to install automatically. Until then there is not much point since the deps are still hardcoded here.
-    install mapnik 3.0.13-1
+    install mapnik 3.0.13-2
 fi

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -3,17 +3,15 @@
 set -eu
 set -o pipefail
 
+./scripts/setup.sh --config local.env
+source local.env
+
 function install() {
-    ./mason/mason install $1 $2
-    ./mason/mason link $1 $2
+    mason install $1 $2
+    mason link $1 $2
 }
 
 ICU_VERSION="57.1"
-
-if [ ! -f ./mason/mason.sh ]; then
-    mkdir -p ./mason
-    curl -sSfL https://github.com/mapbox/mason/archive/d1a9856.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
-fi
 
 if [ ! -f ./mason_packages/.link/bin/mapnik-config ]; then
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-0.7.0}"
+export MASON_RELEASE="${MASON_RELEASE:-8000911}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-3.9.1}"
 
 PLATFORM=$(uname | tr A-Z a-z)
@@ -58,7 +58,7 @@ function run() {
       local mason_release=${2}
       if [[ ! -d ${install_dir} ]]; then
           mkdir -p ${install_dir}
-          curl -sSfL https://github.com/mapbox/mason/archive/v${mason_release}.tar.gz | tar --gunzip --extract --strip-components=1 --directory=${install_dir}
+          curl -sSfL https://github.com/mapbox/mason/archive/${mason_release}.tar.gz | tar --gunzip --extract --strip-components=1 --directory=${install_dir}
       fi
     }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-8000911}"
+export MASON_RELEASE="${MASON_RELEASE:-0618b97}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-3.9.1}"
 
 PLATFORM=$(uname | tr A-Z a-z)


### PR DESCRIPTION
Working on a proof of concept: add specific flags to the release builds to include more debug info for better callstacks when profiling. An attempt to implement https://github.com/mapbox/cpp/blob/master/glossary.md#profiling-build. The question will be whether the binaries are too large (> 1.5 the size). We'll see. If not, then this should overwhelmingly help for profiling and the rare instance of crash debugging.