### PR TITLE
Publish two versions of windows binaries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,27 +8,27 @@ environment:
     - nodejs_version: 0.10.40
       platform: x64
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11 --toolset=v140
+      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
     - nodejs_version: 0.10.40
       platform: x86
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11 --toolset=v140
+      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
     - nodejs_version: 4.4.1
       platform: x86
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11 --toolset=v140
+      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
     - nodejs_version: 4.4.1
       platform: x64
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11 --toolset=v140
+      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
     - nodejs_version: 5.9.1
       platform: x86
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11 --toolset=v140
+      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
     - nodejs_version: 5.9.1
       platform: x64
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11 --toolset=v140
+      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
 
 os: Visual Studio 2015
 

--- a/common.gypi
+++ b/common.gypi
@@ -1,6 +1,7 @@
 {
   'target_defaults': {
     'default_configuration': 'Release',
+    # the v140 refers to vs2015
     'msbuild_toolset':'v140',
     'msvs_disabled_warnings': [ 4068,4244,4005,4506,4345,4804,4805,4661 ],
     'cflags_cc' : [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "http://github.com/mapnik/node-mapnik",
   "homepage": "http://mapnik.org",
   "author": "Dane Springmeyer <dane@mapbox.com> (mapnik.org)",
-  "version": "3.5.16-test",
+  "version": "3.5.16",
   "mapnik_version":"v3.0.13",
   "main": "./lib/mapnik.js",
   "binary": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "http://github.com/mapnik/node-mapnik",
   "homepage": "http://mapnik.org",
   "author": "Dane Springmeyer <dane@mapbox.com> (mapnik.org)",
-  "version": "3.5.16",
+  "version": "3.5.16-test",
   "mapnik_version":"v3.0.13",
   "main": "./lib/mapnik.js",
   "binary": {


### PR DESCRIPTION
We currently only support vs2015 per https://github.com/mapnik/node-mapnik#windows-specific. A common convention with node-pre-gyp modules is to allow users to pass `--toolset=v140` to opt-into binaries built with vs2015. Because node-mapnik only supports vs2015 we provide binaries for both `npm install` (no custom flag) and `npm install --toolset=v140`. This keeps back compatibility with node-mapnik versions pre v3.6.0.

Background at #756.