### PR TITLE
[WIP] Attempt to build on windows against stock node v4 and v6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,43 +4,43 @@ environment:
   node_pre_gyp_secretAccessKey:
     secure: 1amwJJw9fu0j6dXnc5KsAQbSYf7Cjw/dapT6OZWABa6nc52grkKeLQ+DGaOfQz8i
   matrix:
-    # custom visual studio 2015 builds
-    - nodejs_version: 0.10.40
+    - nodejs_version: 0.10
+      msvs_toolset: 14
       platform: x64
+    - nodejs_version: 0.10
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
-    - nodejs_version: 0.10.40
       platform: x86
+    # Fixed at version until https://github.com/nodejs/node/issues/12244 is resolved by nodejs
+    - nodejs_version: 4.8.1
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
-    - nodejs_version: 4.4.1
-      platform: x86
-      msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
-    - nodejs_version: 4.4.1
       platform: x64
+    - nodejs_version: 4.8.1
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
-    - nodejs_version: 5.9.1
       platform: x86
+    # Fixed at version until https://github.com/nodejs/node/issues/12244 is resolved by nodejs
+    - nodejs_version: 6.10.1
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
-    - nodejs_version: 5.9.1
       platform: x64
+    - nodejs_version: 6.10.1
       msvs_toolset: 14
-      TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11
+      platform: x86
+    - nodejs_version: 8
+      msvs_toolset: 14
+      platform: x64
+    - nodejs_version: 8
+      msvs_toolset: 14
+      platform: x86
 
 os: Visual Studio 2015
-
-# Disabled since we're seeing this hang frequently
-#cache:
-#  - mapnik-sdk -> appveyor.yml
 
 clone_depth: 20
 
 install:
-  - git submodule update --init
   - scripts\build-appveyor.bat
+
+artifacts:
+  - path: build\stage\**\*.gz
+    name: package
 
 build: off
 test: off

--- a/common.gypi
+++ b/common.gypi
@@ -3,7 +3,7 @@
     'default_configuration': 'Release',
     # the v140 refers to vs2015
     'msbuild_toolset':'v140',
-    'msvs_disabled_warnings': [ 4068,4244,4005,4506,4345,4804,4805,4661 ],
+    'msvs_disabled_warnings': [ 4503, 4068,4244,4005,4506,4345,4804,4805,4661 ],
     'cflags_cc' : [
       '-std=c++11',
     ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "http://github.com/mapnik/node-mapnik",
   "homepage": "http://mapnik.org",
   "author": "Dane Springmeyer <dane@mapbox.com> (mapnik.org)",
-  "version": "3.6.0",
+  "version": "3.6.0-wintest",
   "mapnik_version":"v3.0.13",
   "main": "./lib/mapnik.js",
   "binary": {
@@ -56,6 +56,7 @@
     "docs": "documentation build src/*.cpp src/mapnik_plugins.hpp --polyglot -o documentation -f html --github --name Mapnik"
   },
   "devDependencies": {
+    "node-gyp": "^3.6.1",
     "aws-sdk": "2.0.12",
     "jshint": "^2.5.10",
     "mocha": "2.x",

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -4,6 +4,14 @@ SET EL=0
 
 ECHO =========== %~f0 ===========
 
+git submodule update --init
+IF %ERRORLEVEL% NEQ 0 ECHO could not update submodules && GOTO ERROR
+
+:: only run Install-Product on AppVeyor
+:: TODO: check requested node version on local builds and bail if it doesn't match
+IF /I "%APPVEYOR%"=="True" powershell Install-Product node %nodejs_version% %PLATFORM%
+IF %ERRORLEVEL% NEQ 0 ECHO could not install requested node version && GOTO ERROR
+
 SET MAPNIK_GIT=
 FOR /F "tokens=*" %%i in ('node -e "console.log(require(""./package.json"").mapnik_version)"') DO SET MAPNIK_GIT=%%i
 
@@ -23,57 +31,10 @@ ECHO extracting mapnik sdk
 IF EXIST mapnik-sdk (ECHO already extracted) ELSE (7z -y x mapnik-sdk.7z | %windir%\system32\FIND "ing archive")
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
-:: replace installed node.exe with Mapbox node.exe
-:: so that the binaries based on Visual Studio 2015
-:: and built by https://travis-ci.org/mapbox/node-cpp11 are used
-SET ARCHPATH=
-IF /I %platform% == x64 (SET ARCHPATH=x64/)
-SET NODE_URL=https://mapbox.s3.amazonaws.com/node-cpp11/v%nodejs_version%/%ARCHPATH%node.exe
-ECHO fetching node.exe^: %NODE_URL%
-powershell Invoke-WebRequest "${env:NODE_URL}" -OutFile node.exe
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
-:: we replace the existing node.exe with our own
-:: we do this in place so that the npm path logic
-:: is preserved. The alternative might be to put
-:: our custom node.exe on PATH from a custom location
-:: and then pass `--prefix` to npm - but this is untested
-ECHO deleting node.exe programfiles x64
-IF EXIST "%ProgramFiles%\nodejs" IF EXIST "%ProgramFiles%\nodejs\node.exe" ECHO found "%ProgramFiles%\nodejs\node.exe", deleting... && DEL /F "%ProgramFiles%\nodejs\node.exe"
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-ECHO copying node.exe to programfiles x64
-IF EXIST %ProgramFiles%\nodejs ECHO copying to "%ProgramFiles%\nodejs\node.exe" && COPY /Y node.exe "%ProgramFiles%\nodejs\"
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
-ECHO deleting node.exe programfiles x86
-IF DEFINED ProgramFiles(x86) IF EXIST "%ProgramFiles(x86)%\nodejs" IF EXIST "%ProgramFiles(x86)%\nodejs\node.exe" ECHO "found %ProgramFiles(x86)%\nodejs\node.exe", deleting... && DEL /F "%ProgramFiles(x86)%\nodejs\node.exe"
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
-ECHO copying node.exe to programfiles x86
-IF DEFINED ProgramFiles(x86) IF EXIST "%ProgramFiles(x86)%\nodejs" ECHO copying to "%ProgramFiles(x86)%\nodejs\node.exe" && COPY /Y node.exe "%ProgramFiles(x86)%\nodejs\"
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
-::delete node.exe in current directory, that newer npm versions put stuff into the right directories
-IF EXIST node.exe DEL node.exe
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-IF EXIST node.pdb DEL node.pdb
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
-:: this is not needed on a fresh machine without previous installs
-:: but is important on a machine that already has compiled for a given
-:: node version. So, we have to clear to ensure that the Visual Studio 2015
-:: binaries are used rather than the ones from joyent (which are built with Visual Studio 2013)
-ECHO clear out node-gyp binary cache to ensure vs 2015 binaries are linked
-IF "%msvs_toolset%" == "14" IF EXIST %USERPROFILE%\.node-gyp rd /s /q %USERPROFILE%\.node-gyp
-
-::upgrade npm to get consistent behaviour with older node versions
-powershell Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-CALL npm install -g npm-windows-upgrade@0.5.3
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-CALL npm-windows-upgrade --version:3.3.2 --no-dns-check --no-prompt
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-
+:: HACK!! to make node@4.x x86 builds work
+:: see: https://github.com/mapbox/node-pre-gyp/issues/209#issuecomment-217690537
+CALL npm config set -g cafile=package.json
+CALL npm config set -g strict-ssl=false
 
 ECHO activating VS command prompt...
 IF /I %platform% == x64 CALL "C:\Program Files (x86)\Microsoft Visual Studio %msvs_toolset%.0\VC\vcvarsall.bat" amd64
@@ -107,14 +68,6 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 IF /I "%NPM_BIN_DIR%"=="%CD%" ECHO ERROR npm bin -g equals local directory && SET ERRORLEVEL=1 && GOTO ERROR
 ECHO ===== where npm puts stuff END ============
 
-:: install node-gyp globally to:
-:: 1) ensure node-gyp can find it (probably optional)
-:: 2) ensure we have recent enough node-gyp to understand VS 2015 (needed for node v0.10.x certainly)
-ECHO installing node-gyp
-CALL npm install -g node-gyp
-IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-ECHO ERRORLEVEL^: %ERRORLEVEL%
-
 :: get ready to build agains the mapnik SDK
 SET MAPNIK_SDK=%CD%\mapnik-sdk
 SET PATH=%MAPNIK_SDK%\bin;%MAPNIK_SDK%\lib;%PATH%
@@ -125,7 +78,7 @@ SET ICU_DATA=%MAPNIK_SDK%\share\icu
 :: actually install deps + compile node-mapnik
 ECHO building node-mapnik
 :: --msvs_version=2015 is passed along to node-gyp here
-CALL npm install --build-from-source --msvs_version=2015 %TOOLSET_ARGS% --loglevel=http
+CALL npm install --build-from-source --msvs_version=2015 --loglevel=http --node_shared=true
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 FOR /F "tokens=*" %%i in ('CALL node_modules\.bin\node-pre-gyp reveal module_path --silent') DO SET NODEMAPNIK_BINDING_DIR=%%i
@@ -155,14 +108,18 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 IF NOT "%CM%" == "%CM:[republish binary]=%" (ECHO republishing v140 ... && CALL node_modules\.bin\node-pre-gyp package unpublish publish --toolset=v140) ELSE (ECHO not republishing)
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
+ECHO packaging ...
+CALL node_modules\.bin\node-pre-gyp package
+IF %ERRORLEVEL% NEQ 0 ECHO error during packaging && GOTO ERROR
+
 :: publish binaries to default path
 :: in the future this may change depending on:
 :: 1) what visual studio versions we support
 :: 2) how visual studio binaries are or are not compatible with each other
 :: more details: https://github.com/mapnik/node-mapnik/issues/756
-IF NOT "%CM%" == "%CM:[publish binary]=%" (ECHO publishing... && CALL node_modules\.bin\node-pre-gyp package publish) ELSE (ECHO not publishing)
+IF NOT "%CM%" == "%CM:[publish binary]=%" (ECHO publishing... && CALL node_modules\.bin\node-pre-gyp publish) ELSE (ECHO not publishing)
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-IF NOT "%CM%" == "%CM:[republish binary]=%" (ECHO republishing ... && CALL node_modules\.bin\node-pre-gyp package unpublish publish) ELSE (ECHO not republishing)
+IF NOT "%CM%" == "%CM:[republish binary]=%" (ECHO republishing ... && CALL node_modules\.bin\node-pre-gyp unpublish publish) ELSE (ECHO not republishing)
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 


### PR DESCRIPTION
Moves build on appveyor to use the normal (aka stock) node.exe from nodejs.org (installed using appveyor shortcuts).


 - Closes https://github.com/mapnik/node-mapnik/issues/691.
 - Unlocks node v6 support

TODO:

 - [x] node v0.10.x support
 - [x] Followup on https://github.com/mapnik/node-mapnik/issues/756
 - [x] Followup on https://github.com/mapbox/node-cpp11/issues/28