### PR TITLE
Pass variables into grid_renderer

### DIFF
--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -2243,7 +2243,12 @@ void Map::EIO_RenderGrid(uv_work_t* req)
             attributes.insert(join_field);
         }
 
-        mapnik::grid_renderer<mapnik::grid> ren(*closure->m->map_,
+        mapnik::Map const& map = *closure->m->map_;
+        mapnik::request m_req(map.width(),map.height(),map.get_current_extent());
+        m_req.set_buffer_size(closure->buffer_size);
+        mapnik::grid_renderer<mapnik::grid> ren(map,
+                                                m_req,
+                                                closure->variables,
                                                 *closure->g->get(),
                                                 closure->scale_factor,
                                                 closure->offset_x,


### PR DESCRIPTION
Use a similar approach as in EIO_RenderImage, making variables available at renderer/datasource level.

It should fix #768.