### PR TITLE
Adding mapnik.Image.parseSVGMetaBytesSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.7.0
+
+Adds `mapnik.Image.parseSVGMetaBytesSync` to allow users to get the width and height of an svg buffer by using `mapnik.Image`'s svg parsing logic.
+
 ## 3.6.2
 
 Updated to 3.0.15 of mapnik. The full changelog for this release is located [here](https://github.com/mapnik/mapnik/blob/master/CHANGELOG.md#3015). 

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -125,6 +125,9 @@ void Image::Initialize(v8::Local<v8::Object> target) {
                     "openSync",
                     Image::openSync);
     Nan::SetMethod(lcons->GetFunction().As<v8::Object>(),
+                    "parseSVGMetaBytesSync",
+                    Image::parseSVGMetaBytesSync);
+    Nan::SetMethod(lcons->GetFunction().As<v8::Object>(),
                     "fromBytesSync",
                     Image::fromBytesSync);
     Nan::SetMethod(lcons->GetFunction().As<v8::Object>(),
@@ -2517,11 +2520,77 @@ void Image::EIO_AfterOpen(uv_work_t* req)
 }
 
 /**
+ * parse metadata for an SVG from a buffer (synchronous)
+ * @name parseSVGMetaBytesSync
+ * @memberof Image
+ * @static
+ * @param {Buffer} buffer - buffer of SVG image
+ * @returns {Object} [metadata] - an object with width and height
+ * @example
+ * var buffer = fs.readFileSync('./path/to/image.svg');
+ * var metadata = mapnik.Image.parseSVGMetaBytesSync(buffer);
+ */
+NAN_METHOD(Image::parseSVGMetaBytesSync)
+{
+    if (info.Length() == 0 || !info[0]->IsObject()) {
+      Nan::ThrowTypeError("first argument is invalid, must be a Buffer");
+      return;
+    }
+
+    v8::Local<v8::Object> obj = info[0]->ToObject();
+    if (!node::Buffer::HasInstance(obj)) {
+        Nan::ThrowTypeError("first argument is invalid, must be a Buffer");
+        return;
+    }
+
+    try
+    {
+        using namespace mapnik::svg;
+        mapnik::svg_path_ptr marker_path(std::make_shared<mapnik::svg_storage_type>());
+        vertex_stl_adapter<svg_path_storage> stl_storage(marker_path->source());
+        svg_path_adapter svg_path(stl_storage);
+        svg_converter_type svg(svg_path, marker_path->attributes());
+        svg_parser p(svg);
+
+        std::string svg_buffer(node::Buffer::Data(obj), node::Buffer::Length(obj));
+        if (!p.parse_from_string(svg_buffer))
+        {
+            std::ostringstream errorMessage("");
+            errorMessage << "SVG parse error:" << std::endl;
+            auto const& errors = p.error_messages();
+            for (auto error : errors) {
+                errorMessage <<  error << std::endl;
+            }
+            Nan::ThrowTypeError(errorMessage.str().c_str());
+            return;
+        }
+
+        v8::Local<v8::Object> meta = Nan::New<v8::Object>();
+        meta->Set(Nan::New("width").ToLocalChecked(),
+            Nan::New<v8::Int32>(static_cast<std::int32_t>(svg.width())));
+        meta->Set(Nan::New("height").ToLocalChecked(),
+            Nan::New<v8::Int32>(static_cast<std::int32_t>(svg.height())));
+        info.GetReturnValue().Set(meta);
+
+    }
+    catch (std::exception const& ex)
+    {
+        // There is currently no known way to make these operations throw an exception, however,
+        // since the underlying agg library does possibly have some operation that might throw
+        // it is a good idea to keep this. Therefore, any exceptions thrown will fail gracefully.
+        // LCOV_EXCL_START
+        Nan::ThrowError(ex.what());
+        return;
+        // LCOV_EXCL_STOP
+    }
+}
+
+/**
  * Load image from an SVG buffer (synchronous)
  * @name fromSVGBytesSync
  * @memberof Image
  * @static
- * @param {string} path - path to SVG image
+ * @param {Buffer} buffer - buffer of SVG image
  * @param {Object} [options]
  * @param {number} [options.scale] - scale the image. For example passing `0.5` as scale would render
  * your SVG at 50% the original size.
@@ -2978,7 +3047,7 @@ void Image::EIO_AfterFromSVG(uv_work_t* req)
  * @param {Function} callback = `function(err, img)`
  * @example
  * var buffer = fs.readFileSync('./path/to/image.svg');
- * mapnik.Image.fromSVGBytesSync(buffer, function(err, img) {
+ * mapnik.Image.fromSVGBytes(buffer, function(err, img) {
  *   if (err) throw err;
  *   // your custom code with `img`
  * });

--- a/src/mapnik_image.hpp
+++ b/src/mapnik_image.hpp
@@ -48,6 +48,7 @@ public:
     static NAN_METHOD(fromBytes);
     static void EIO_FromBytes(uv_work_t* req);
     static void EIO_AfterFromBytes(uv_work_t* req);
+    static NAN_METHOD(parseSVGMetaBytesSync);
     static v8::Local<v8::Value> _fromSVGSync(bool fromFile, Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(fromSVGSync);
     static NAN_METHOD(fromSVG);

--- a/test/image.svg.meta.test.js
+++ b/test/image.svg.meta.test.js
@@ -1,0 +1,41 @@
+/* global describe it */
+
+'use strict';
+
+var mapnik = require('../');
+var assert = require('assert');
+var fs = require('fs');
+
+describe('mapnik.Image SVG Meta', function() {
+    it('should throw with invalid usage', function() {
+        assert.throws(function() { mapnik.Image.parseSVGMetaBytesSync(); });
+        assert.throws(function() { mapnik.Image.parseSVGMetaBytesSync('fail'); });
+        assert.throws(function() { mapnik.Image.parseSVGMetaBytesSync(null); });
+        assert.throws(function() { mapnik.Image.parseSVGMetaBytesSync({}); });
+        assert.throws(function() {
+            new mapnik.Image.parseSVGMetaBytesSync(new Buffer('asdfasdf'));
+        }, /SVG parse error:\s+Unable to parse 'asdfasdf'/);
+        assert.throws(function() {
+            mapnik.Image.fromSVGSync('./test/data/vector_tile/tile0.corrupt-svg.svg');
+        }, /image created from svg must have a width and height greater then zero/);
+    });
+
+    it('should return an object with width and height', function(done) { 
+        fs.readFile('./test/data/vector_tile/tile0.expected-svg.svg', function(err, buffer) {
+            assert.ifError(err); 
+            var meta = mapnik.Image.parseSVGMetaBytesSync(buffer);
+            assert.equal(256, meta.width);
+            assert.equal(256, meta.height);
+            done();
+        });
+    });
+
+    it('should handle svgs with a really really large size', function(done) {
+        var svgdata = "<svg width='2147483647' height='2147483647'><g id='a'><ellipse fill='#FFFFFF' stroke='#000000' stroke-width='4' cx='50' cy='50' rx='25' ry='25'/></g></svg>";
+        var buffer = new Buffer(svgdata);
+        var meta = mapnik.Image.parseSVGMetaBytesSync(buffer);
+        assert.equal(2147483647, meta.width);
+        assert.equal(2147483647, meta.height);
+        done();
+    });
+});

--- a/test/image.svg.test.js
+++ b/test/image.svg.test.js
@@ -12,6 +12,9 @@ describe('mapnik.Image SVG', function() {
         assert.throws(function() { new mapnik.Image.fromSVG(); });
         assert.throws(function() { new mapnik.Image.fromSVGBytes(); });
         assert.throws(function() {
+          new mapnik.Image.fromSVGBytesSync(null);
+        }, /must provide a buffer argument/);
+        assert.throws(function() {
           new mapnik.Image.fromSVGBytesSync(1);
         }, /must provide a buffer argument/);
         assert.throws(function() {


### PR DESCRIPTION
This PR adds support for returning the metadata (currently width and height) that Mapnik pulls out of an SVG without needing to turn the SVG into and Image. It was inspired by [this discussion](https://github.com/mapbox/spritezero/issues/51#issuecomment-310189704).

This is my first C++ PR so any input as the PR develops would be great 😄 

## Questions:

I'm using `[x]` to indicate that this question has been answered.

- [ ] Should this be on `mapnik.Image` or on `mapnik`?
- [ ] The other SVG methods include path, buffer and sync options. Should this support all of those too? If so, is SyncBuffer a good first PR?