### PR TITLE
Wrap environment variables in quotes for js module

### DIFF
--- a/gen_settings.py
+++ b/gen_settings.py
@@ -11,13 +11,19 @@ module.exports.paths = {
 };
 """
 
+def wrap_quotes(v):
+    # Conditionally wrap an environment variable in quotes
+    for i in ["'",'"']:
+        if v[0] == v[-1] == i:
+            return v
+    return '\'%s\'' % v
+
 def write_mapnik_settings(fonts='undefined',input_plugins='undefined'):
     global settings_template
     if '__dirname' in fonts or '__dirname' in input_plugins:
         settings_template = "var path = require('path');\n" + settings_template
     open(settings,'w').write(settings_template % (fonts,input_plugins))
-
-
+    
 if __name__ == '__main__':
     settings_dict = {}
     
@@ -26,13 +32,13 @@ if __name__ == '__main__':
     # https://github.com/mapbox/tilemill/blob/master/platforms/windows/package.bat#L37
     ip = os.environ.get('MAPNIK_INPUT_PLUGINS')
     if ip:
-        settings_dict['input_plugins'] = ip
+        settings_dict['input_plugins'] = wrap_quotes(ip)
     else:
         settings_dict['input_plugins'] = '\'%s\'' % os.popen("./mason_packages/.link/bin/mapnik-config --input-plugins").readline().strip()
     
     mf = os.environ.get('MAPNIK_FONTS')
     if mf:
-        settings_dict['fonts'] = mf
+        settings_dict['fonts'] = wrap_quotes(mf)
     else:
         settings_dict['fonts'] = '\'%s\'' % os.popen("./mason_packages/.link/bin/mapnik-config --fonts").readline().strip()
 


### PR DESCRIPTION
Normally shell-escaped environment variables `MAPNIK_FONTS` and `MAPNIK_INPUT_PLUGINS` (without extra quotes) produce invalid javascript due to unquoted string literals in template string. Added some conditional quoting.

There should also be another option to pull these variables from a non-mason `mapnik-config` but that is likely for another time.