### PR TITLE
Allow using local mapnik installation for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,27 @@ default: release
 deps/geometry/include/mapbox/geometry.hpp:
 	git submodule update --init
 
-mason_packages/.link/bin/mapnik-config: deps/geometry/include/mapbox/geometry.hpp
-	./install_mason.sh
-
-node_modules: mason_packages/.link/bin/mapnik-config
-	# install deps but for now ignore our own install script
-	# so that we can run it directly in either debug or release
+node_modules:
 	npm install --ignore-scripts --clang
 
-release: node_modules
-	PATH="./mason_packages/.link/bin/:${PATH}" && V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
+mason_packages/.link/bin/mapnik-config:
+	./install_mason.sh
+
+pre_build_check: ; @which mapnik-config > /dev/null
+
+release_base: pre_build_check deps/geometry/include/mapbox/geometry.hpp node_modules
+	V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
 	@echo "run 'make clean' for full rebuild"
 
-debug: node_modules
-	PATH="./mason_packages/.link/bin/:${PATH}" && V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --debug --clang
+debug_base: pre_build_check deps/geometry/include/mapbox/geometry.hpp node_modules
+	V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --debug --clang
 	@echo "run 'make clean' for full rebuild"
+
+release: mason_packages/.link/bin/mapnik-config
+	PATH="./mason_packages/.link/bin/:${PATH}" $(MAKE) release_base
+
+debug: mason_packages/.link/bin/mapnik-config
+	PATH="./mason_packages/.link/bin/:${PATH}" $(MAKE) debug_base
 
 coverage:
 	./scripts/coverage.sh
@@ -49,6 +55,7 @@ docs:
 
 test:
 	npm test
+check: test
 
 testpack:
 	rm -f ./*tgz

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The **1.x** series require the Visual C++ Redistributable Packages for **Visual 
 
 ## Source Build
 
+### Using a local Mapnik installation
+
 To build from source you need:
 
  - Mapnik >= v3.0.10
@@ -153,6 +155,19 @@ Confirm that the `mapnik-config` program is available and on your `${PATH}`.
 Then run (within the cloned `node-mapnik` directory:
 
     npm install --build-from-source
+
+### Linux and OSX specific (Makefile)
+
+You can also build from source using the provided Makefile. In this case there are two main options: use mason to download Mapnik and its dependencies, or use your local Mapnik installation.
+
+To download and build against the latest Mapnik archive, use the the `release` or `debug` targets. For example:
+
+    make release
+
+To build against you local installation (requires `mapnik-config` to be in the `${PATH}`), you can use `release_base` and `debug_base` targers. For example:
+
+    make debug_base
+
 
 ### Windows specific
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -97,7 +97,6 @@
             'cflags_cc!': ['-fno-rtti', '-fno-exceptions'],
             'cflags_cc' : [
               '<!@(mapnik-config --cflags)',
-              '-D_GLIBCXX_USE_CXX11_ABI=0'
             ],
             'libraries':[
               '<!@(mapnik-config --libs)',

--- a/gen_settings.py
+++ b/gen_settings.py
@@ -28,12 +28,12 @@ if __name__ == '__main__':
     if ip:
         settings_dict['input_plugins'] = ip
     else:
-        settings_dict['input_plugins'] = '\'%s\'' % os.popen("./mason_packages/.link/bin/mapnik-config --input-plugins").readline().strip()
+        settings_dict['input_plugins'] = '\'%s\'' % os.popen("mapnik-config --input-plugins").readline().strip()
     
     mf = os.environ.get('MAPNIK_FONTS')
     if mf:
         settings_dict['fonts'] = mf
     else:
-        settings_dict['fonts'] = '\'%s\'' % os.popen("./mason_packages/.link/bin/mapnik-config --fonts").readline().strip()
+        settings_dict['fonts'] = '\'%s\'' % os.popen("mapnik-config --fonts").readline().strip()
 
     write_mapnik_settings(**settings_dict)

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -5,6 +5,25 @@ set -o pipefail
 MODULE_PATH=./lib/binding
 MAPNIK_SDK=./mason_packages/.link
 
+# Check if we are using Mason's mapnik
+if [[ ! "$(which mapnik-config)" -ef "$MAPNIK_SDK/bin/mapnik-config" ]]; then
+  echo "
+var path = require('path');
+module.exports.paths = {
+    'fonts':         '$(mapnik-config --fonts)',
+    'input_plugins': '$(mapnik-config --input-plugins)',
+    'mapnik_index':  '$(which mapnik-index)',
+    'shape_index':   '$(which shapeindex)'
+};
+module.exports.env = {
+    'ICU_DATA':      '$(mapnik-config --icu-data)',
+    'GDAL_DATA':     '$(mapnik-config --gdal-data)',
+    'PROJ_LIB':      '$(mapnik-config --proj-lib)'
+};
+" > ${MODULE_PATH}/mapnik_settings.js
+  exit 0;
+fi
+
 mkdir -p ${MODULE_PATH}/bin/
 
 # the below switch is used since on osx the default cp


### PR DESCRIPTION
Changes to allow building against a local installation of mapnik by using `make release_base` or `make debug_base`; it requires  `mapnik-config` to be in the PATH.

The default build is still using mason (downloads mason and its dependencies and sets the PATH to use it).  I'm not completely sure if the changes in postinstall are correct, though. I've tested this only on LInux, with these changes on top of v3.6.2 and mapnik 3.0.15 (with a cherry-pick for icu-59)

It should cover https://github.com/mapnik/node-mapnik/issues/784
