### PR TITLE
add debugging symbols to release builds - refs #753

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@ MODULE_NAME := $(shell node -e "console.log(require('./package.json').binary.mod
 
 default: release
 
+ifneq (,$(findstring clang,$(CXX)))
+    PROFILING_FLAG += -gline-tables-only
+else
+    PROFILING_FLAG += -g
+endif
+
 deps/geometry/include/mapbox/geometry.hpp:
 	git submodule update --init
 
@@ -17,7 +23,7 @@ pre_build_check:
 	mapnik-config -v
 
 release_base: pre_build_check deps/geometry/include/mapbox/geometry.hpp node_modules
-	V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
+	V=1 CXXFLAGS="-fno-omit-frame-pointer $(PROFILING_FLAG)" ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
 	@echo "run 'make clean' for full rebuild"
 
 debug_base: pre_build_check deps/geometry/include/mapbox/geometry.hpp node_modules


### PR DESCRIPTION
This starts building mapnik.node with `-g` even in release mode to accomplish release builds with better debugging symbols for profiling and crash debugging that should have no perf impact. The binary size goes from 3 MB to 3.4 MB on OSX, which is acceptable (I assume similar on linux). 

refs https://github.com/mapbox/cpp/blob/master/glossary.md#profiling-build

#753 is an attempt at building both mapnik core and node-mapnik with debug symbols, but I am worried that will add to much size growth to libmapnik.so, so I'm pausing work in #753 and will land this instead.

/cc @GretaCB 