### PR TITLE
isolate changes unrelated to mapnik 3.1 from #805

### DIFF
--- a/src/mapnik_color.cpp
+++ b/src/mapnik_color.cpp
@@ -13,7 +13,7 @@ Nan::Persistent<v8::FunctionTemplate> Color::constructor;
 /**
  * **`mapnik.Color`**
  *
- * A `mapnik.Color` object used for handling and converting colors 
+ * A `mapnik.Color` object used for handling and converting colors
  *
  * @class Color
  * @param {string|number} value either an array of [r, g, b, a],
@@ -81,12 +81,12 @@ NAN_METHOD(Color::New)
     color_ptr c_p;
     try
     {
-        if (info.Length() == 1 && 
+        if (info.Length() == 1 &&
             info[0]->IsString())
         {
             c_p = std::make_shared<mapnik::color>(TOSTR(info[0]));
         }
-        else if (info.Length() == 2 && 
+        else if (info.Length() == 2 &&
                  info[0]->IsString() &&
                  info[1]->IsBoolean())
         {
@@ -95,7 +95,7 @@ NAN_METHOD(Color::New)
         else if (info.Length() == 3 &&
                  info[0]->IsNumber() &&
                  info[1]->IsNumber() &&
-                 info[2]->IsNumber()) 
+                 info[2]->IsNumber())
         {
             int r = info[0]->IntegerValue();
             int g = info[1]->IntegerValue();
@@ -106,12 +106,12 @@ NAN_METHOD(Color::New)
                 return;
             }
             c_p = std::make_shared<mapnik::color>(r,g,b);
-        } 
+        }
         else if (info.Length() == 4 &&
                  info[0]->IsNumber() &&
                  info[1]->IsNumber() &&
                  info[2]->IsNumber() &&
-                 info[3]->IsBoolean()) 
+                 info[3]->IsBoolean())
         {
             int r = info[0]->IntegerValue();
             int g = info[1]->IntegerValue();
@@ -122,12 +122,12 @@ NAN_METHOD(Color::New)
                 return;
             }
             c_p = std::make_shared<mapnik::color>(r,g,b,255,info[3]->BooleanValue());
-        } 
+        }
         else if (info.Length() == 4 &&
                  info[0]->IsNumber() &&
                  info[1]->IsNumber() &&
                  info[2]->IsNumber() &&
-                 info[3]->IsNumber()) 
+                 info[3]->IsNumber())
         {
             int r = info[0]->IntegerValue();
             int g = info[1]->IntegerValue();
@@ -139,13 +139,13 @@ NAN_METHOD(Color::New)
                 return;
             }
             c_p = std::make_shared<mapnik::color>(r,g,b,a);
-        } 
+        }
         else if (info.Length() == 5 &&
                  info[0]->IsNumber() &&
                  info[1]->IsNumber() &&
                  info[2]->IsNumber() &&
                  info[3]->IsNumber() &&
-                 info[4]->IsBoolean()) 
+                 info[4]->IsBoolean())
         {
             int r = info[0]->IntegerValue();
             int g = info[1]->IntegerValue();
@@ -157,8 +157,8 @@ NAN_METHOD(Color::New)
                 return;
             }
             c_p = std::make_shared<mapnik::color>(r,g,b,a,info[4]->BooleanValue());
-        } 
-        else 
+        }
+        else
         {
             Nan::ThrowTypeError("invalid arguments: colors can be created from a string, integer r,g,b values, or integer r,g,b,a values");
             return;
@@ -183,9 +183,10 @@ v8::Local<v8::Value> Color::NewInstance(mapnik::color const& color) {
     Color* c = new Color();
     c->this_ = std::make_shared<mapnik::color>(color);
     v8::Local<v8::Value> ext = Nan::New<v8::External>(c);
-    return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Color instance");
+    return scope.Escape(maybe_local.ToLocalChecked());
 }
-
 
 NAN_GETTER(Color::get_prop)
 {

--- a/src/mapnik_datasource.cpp
+++ b/src/mapnik_datasource.cpp
@@ -147,7 +147,9 @@ v8::Local<v8::Value> Datasource::NewInstance(mapnik::datasource_ptr ds_ptr) {
     Datasource* d = new Datasource();
     d->datasource_ = ds_ptr;
     v8::Local<v8::Value> ext = Nan::New<v8::External>(d);
-    return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Datasource instance");
+    return scope.Escape(maybe_local.ToLocalChecked());
 }
 
 NAN_METHOD(Datasource::parameters)

--- a/src/mapnik_feature.cpp
+++ b/src/mapnik_feature.cpp
@@ -114,7 +114,9 @@ NAN_METHOD(Feature::fromJSON)
         }
         Feature* feat = new Feature(f);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(feat);
-        info.GetReturnValue().Set(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Feature instance");
+        else info.GetReturnValue().Set(maybe_local.ToLocalChecked());
     }
     catch (std::exception const& ex)
     {
@@ -132,7 +134,9 @@ v8::Local<v8::Value> Feature::NewInstance(mapnik::feature_ptr f_ptr)
     Nan::EscapableHandleScope scope;
     Feature* f = new Feature(f_ptr);
     v8::Local<v8::Value> ext = Nan::New<v8::External>(f);
-    return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Feature instance");
+    return scope.Escape(maybe_local.ToLocalChecked());
 }
 
 /**

--- a/src/mapnik_featureset.cpp
+++ b/src/mapnik_featureset.cpp
@@ -5,7 +5,7 @@ Nan::Persistent<v8::FunctionTemplate> Featureset::constructor;
 
 /**
  * **`mapnik.Featureset`**
- * 
+ *
  * An iterator of {@link mapnik.Feature} objects.
  *
  * @class Featureset
@@ -74,10 +74,10 @@ NAN_METHOD(Featureset::next)
         }
         catch (std::exception const& ex)
         {
-            // It is not immediately obvious how this could cause an exception, a check of featureset plugin 
+            // It is not immediately obvious how this could cause an exception, a check of featureset plugin
             // implementations resulted in no obvious way that an exception could be raised. Therefore, it
             // is not obvious currently what could raise this exception. However, since a plugin could possibly
-            // be developed outside of mapnik core plugins that could raise here we are probably best still 
+            // be developed outside of mapnik core plugins that could raise here we are probably best still
             // wrapping this in a try catch.
             /* LCOV_EXCL_START */
             Nan::ThrowError(ex.what());
@@ -98,5 +98,7 @@ v8::Local<v8::Value> Featureset::NewInstance(mapnik::featureset_ptr fsp)
     Featureset* fs = new Featureset();
     fs->this_ = fsp;
     v8::Local<v8::Value> ext = Nan::New<v8::External>(fs);
-    return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Featureset instance");
+    return scope.Escape(maybe_local.ToLocalChecked());
 }

--- a/src/mapnik_geometry.cpp
+++ b/src/mapnik_geometry.cpp
@@ -88,7 +88,9 @@ v8::Local<v8::Value> Geometry::NewInstance(mapnik::feature_ptr f) {
     Nan::EscapableHandleScope scope;
     Geometry* g = new Geometry(f);
     v8::Local<v8::Value> ext = Nan::New<v8::External>(g);
-    return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Geometry instance");
+    return scope.Escape(maybe_local.ToLocalChecked());
 }
 
 /**

--- a/src/mapnik_grid_view.cpp
+++ b/src/mapnik_grid_view.cpp
@@ -83,7 +83,9 @@ v8::Local<v8::Value> GridView::NewInstance(Grid * JSGrid,
     GridView* gv = new GridView(JSGrid);
     gv->this_ = std::make_shared<mapnik::grid_view>(JSGrid->get()->get_view(x,y,w,h));
     v8::Local<v8::Value> ext = Nan::New<v8::External>(gv);
-    return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new GridView instance");
+    return scope.Escape(maybe_local.ToLocalChecked());
 }
 
 NAN_METHOD(GridView::width)
@@ -301,7 +303,7 @@ NAN_METHOD(GridView::encodeSync)
             }
 
             resolution = bind_opt->IntegerValue();
-            
+
             if (resolution == 0)
             {
                 Nan::ThrowTypeError("'resolution' can not be zero");

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -1615,8 +1615,9 @@ void Image::EIO_AfterCopy(uv_work_t* req)
     {
         Image* im = new Image(closure->im2);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
-        v8::Local<v8::Object> image_obj = Nan::New(constructor)->GetFunction()->NewInstance(1, &ext);
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), image_obj };
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
     closure->im1->Unref();
@@ -1733,7 +1734,9 @@ v8::Local<v8::Value> Image::_copySync(Nan::NAN_METHOD_ARGS_TYPE info)
                                                     );
         Image* new_im = new Image(imagep);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(new_im);
-        return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        return scope.Escape(maybe_local.ToLocalChecked());
     }
     catch (std::exception const& ex)
     {
@@ -2077,8 +2080,9 @@ void Image::EIO_AfterResize(uv_work_t* req)
     {
         Image* im = new Image(closure->im2);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
-        v8::Local<v8::Object> image_obj = Nan::New(constructor)->GetFunction()->NewInstance(1, &ext);
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), image_obj };
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
     closure->im1->Unref();
@@ -2263,7 +2267,9 @@ v8::Local<v8::Value> Image::_resizeSync(Nan::NAN_METHOD_ARGS_TYPE info)
         mapnik::util::apply_visitor(visit, *imagep);
         Image* new_im = new Image(imagep);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(new_im);
-        return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        return scope.Escape(maybe_local.ToLocalChecked());
     }
     catch (std::exception const& ex)
     {
@@ -2372,7 +2378,9 @@ v8::Local<v8::Value> Image::_openSync(Nan::NAN_METHOD_ARGS_TYPE info)
                 }
                 Image* im = new Image(imagep);
                 v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
-                return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+                v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+                if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+                return scope.Escape(maybe_local.ToLocalChecked());
             }
         }
         Nan::ThrowTypeError(("Unsupported image format:" + filename).c_str());
@@ -2508,8 +2516,9 @@ void Image::EIO_AfterOpen(uv_work_t* req)
     {
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
-        v8::Local<v8::Object> image_obj = Nan::New(constructor)->GetFunction()->NewInstance(1, &ext);
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), image_obj };
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
     closure->cb.Reset();
@@ -2716,7 +2725,9 @@ v8::Local<v8::Value> Image::_fromSVGSync(bool fromFile, Nan::NAN_METHOD_ARGS_TYP
         image_ptr imagep = std::make_shared<mapnik::image_any>(im);
         Image *im2 = new Image(imagep);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im2);
-        return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        return scope.Escape(maybe_local.ToLocalChecked());
     }
     catch (std::exception const& ex)
     {
@@ -2952,8 +2963,9 @@ void Image::EIO_AfterFromSVG(uv_work_t* req)
     {
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
-        v8::Local<v8::Object> image_obj = Nan::New(constructor)->GetFunction()->NewInstance(1, &ext);
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), image_obj };
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
     closure->cb.Reset();
@@ -3284,10 +3296,11 @@ v8::Local<v8::Value> Image::_fromBufferSync(Nan::NAN_METHOD_ARGS_TYPE info)
         image_ptr imagep = std::make_shared<mapnik::image_any>(im_wrapper);
         Image* im = new Image(imagep);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
-        v8::Local<v8::Value> image_instance = Nan::New(constructor)->GetFunction()->NewInstance(1, &ext);
-        v8::Local<v8::Object> image_obj = image_instance->ToObject();
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        v8::Local<v8::Object> image_obj = maybe_local.ToLocalChecked()->ToObject();
         image_obj->Set(Nan::New("_buffer").ToLocalChecked(),obj);
-        return scope.Escape(image_instance);
+        return scope.Escape(maybe_local.ToLocalChecked());
     }
     catch (std::exception const& ex)
     {
@@ -3339,7 +3352,9 @@ v8::Local<v8::Value> Image::_fromBytesSync(Nan::NAN_METHOD_ARGS_TYPE info)
             image_ptr imagep = std::make_shared<mapnik::image_any>(reader->read(0,0,reader->width(),reader->height()));
             Image* im = new Image(imagep);
             v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
-            return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+            v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+            if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+            return scope.Escape(maybe_local.ToLocalChecked());
         }
         // The only way this is ever reached is if the reader factory in
         // mapnik was not providing an image type it should. This should never
@@ -3508,8 +3523,9 @@ void Image::EIO_AfterFromBytes(uv_work_t* req)
     {
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
-        v8::Local<v8::Object> image_obj = Nan::New(constructor)->GetFunction()->NewInstance(1, &ext);
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), image_obj };
+        v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
     closure->cb.Reset();

--- a/src/mapnik_layer.cpp
+++ b/src/mapnik_layer.cpp
@@ -111,7 +111,9 @@ v8::Local<v8::Value> Layer::NewInstance(mapnik::layer const& lay_ref) {
     // copy new mapnik::layer into the shared_ptr
     l->layer_ = std::make_shared<mapnik::layer>(lay_ref);
     v8::Local<v8::Value> ext = Nan::New<v8::External>(l);
-    return scope.Escape(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Layer instance");
+    return scope.Escape(maybe_local.ToLocalChecked());
 }
 
 NAN_GETTER(Layer::get_prop)
@@ -147,25 +149,25 @@ NAN_GETTER(Layer::get_prop)
         }
         return;
     }
-    else if (a == "minimum_scale_denominator") 
+    else if (a == "minimum_scale_denominator")
     {
-        info.GetReturnValue().Set(Nan::New<v8::Number>(l->layer_->minimum_scale_denominator()));   
+        info.GetReturnValue().Set(Nan::New<v8::Number>(l->layer_->minimum_scale_denominator()));
     }
-    else if (a == "maximum_scale_denominator") 
+    else if (a == "maximum_scale_denominator")
     {
-        info.GetReturnValue().Set(Nan::New<v8::Number>(l->layer_->maximum_scale_denominator()));   
+        info.GetReturnValue().Set(Nan::New<v8::Number>(l->layer_->maximum_scale_denominator()));
     }
-    else if (a == "queryable") 
+    else if (a == "queryable")
     {
-        info.GetReturnValue().Set(Nan::New<v8::Boolean>(l->layer_->queryable()));   
+        info.GetReturnValue().Set(Nan::New<v8::Boolean>(l->layer_->queryable()));
     }
-    else if (a == "clear_label_cache") 
+    else if (a == "clear_label_cache")
     {
-        info.GetReturnValue().Set(Nan::New<v8::Boolean>(l->layer_->clear_label_cache()));   
+        info.GetReturnValue().Set(Nan::New<v8::Boolean>(l->layer_->clear_label_cache()));
     }
-    else // if (a == "active") 
+    else // if (a == "active")
     {
-        info.GetReturnValue().Set(Nan::New<v8::Boolean>(l->layer_->active()));   
+        info.GetReturnValue().Set(Nan::New<v8::Boolean>(l->layer_->active()));
     }
 }
 
@@ -283,7 +285,7 @@ NAN_METHOD(Layer::describe)
 
     v8::Local<v8::Object> description = Nan::New<v8::Object>();
     mapnik::layer const& layer = *l->layer_;
-        
+
     description->Set(Nan::New("name").ToLocalChecked(), Nan::New<v8::String>(layer.name()).ToLocalChecked());
 
     description->Set(Nan::New("srs").ToLocalChecked(), Nan::New<v8::String>(layer.srs()).ToLocalChecked());

--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -611,7 +611,7 @@ typedef struct {
  * @param {String|number} [options.layer] - layer name (string) or index (positive integer, 0 index)
  * to query. If left blank, will query all layers.
  * @param {Function} callback
- * @returns {Array} array - An array of `Featureset` objects and layer names, which each contain their own 
+ * @returns {Array} array - An array of `Featureset` objects and layer names, which each contain their own
  * `Feature` objects.
  * @example
  * // iterate over the first layer returned and get all attribute information for each feature
@@ -626,7 +626,7 @@ typedef struct {
  *   }
  *   console.log(attributes); // => [{"attr_key": "attr_value"}, {...}, {...}]
  * });
- * 
+ *
  */
 NAN_METHOD(Map::queryMapPoint)
 {
@@ -635,7 +635,7 @@ NAN_METHOD(Map::queryMapPoint)
 }
 
 /**
- * Query a `Mapnik#Map` object to retrieve layer and feature data based on geographic 
+ * Query a `Mapnik#Map` object to retrieve layer and feature data based on geographic
  * coordinates of the source data (use `Map#queryMapPoint` to query with XY coordinates).
  *
  * @name queryPoint
@@ -647,7 +647,7 @@ NAN_METHOD(Map::queryMapPoint)
  * @param {String|number} [options.layer] - layer name (string) or index (positive integer, 0 index)
  * to query. If left blank, will query all layers.
  * @param {Function} callback
- * @returns {Array} array - An array of `Featureset` objects and layer names, which each contain their own 
+ * @returns {Array} array - An array of `Featureset` objects and layer names, which each contain their own
  * `Feature` objects.
  * @example
  * // query based on web mercator coordinates
@@ -662,7 +662,7 @@ NAN_METHOD(Map::queryMapPoint)
  *   }
  *   console.log(attributes); // => [{"attr_key": "attr_value"}, {...}, {...}]
  * });
- * 
+ *
  */
 NAN_METHOD(Map::queryPoint)
 {
@@ -1456,7 +1456,9 @@ NAN_METHOD(Map::clone)
     Map* m2 = new Map();
     m2->map_ = std::make_shared<mapnik::Map>(*m->map_);
     v8::Local<v8::Value> ext = Nan::New<v8::External>(m2);
-    info.GetReturnValue().Set(Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Map instance");
+    else info.GetReturnValue().Set(maybe_local.ToLocalChecked());
 }
 
 /**
@@ -1667,8 +1669,8 @@ struct vector_tile_baton_t {
  * @param {Object} [options={}]
  * @param {Number} [options.buffer_size=0] size of the buffer on the image
  * @param {Number} [options.scale=1.0] scale the image
- * @param {Number} [options.scale_denominator=0.0] 
- * @param {Number} [options.offset_x=0] pixel offset along the x-axis 
+ * @param {Number} [options.scale_denominator=0.0]
+ * @param {Number} [options.offset_x=0] pixel offset along the x-axis
  * @param {Number} [options.offset_y=0] pixel offset along the y-axis
  * @param {String} [options.image_scaling] must be a valid scaling method (used when rendering a vector tile)
  * @param {String} [options.image_format] must be a string and valid image format (used when rendering a vector tile)
@@ -1676,23 +1678,23 @@ struct vector_tile_baton_t {
  * @param {Boolean} [options.strictly_simple=] ensure all geometry is valid according to
  * OGC Simple definition (used when rendering a vector tile)
  * @param {Boolean} [options.multi_polygon_union] union all multipolygons (used when rendering a vector tile)
- * @param {String} [options.fill_type] the fill type used in determining what are holes and what are outer rings. See the 
+ * @param {String} [options.fill_type] the fill type used in determining what are holes and what are outer rings. See the
  * [Clipper documentation](http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Types/PolyFillType.htm)
  * to learn more about fill types. (used when rendering a vector tile)
  * @param {String} [options.threading_mode] (used when rendering a vector tile)
- * @param {Number} [options.simplify_distance] Simplification works to generalize 
- * geometries before encoding into vector tiles.simplification distance The 
+ * @param {Number} [options.simplify_distance] Simplification works to generalize
+ * geometries before encoding into vector tiles.simplification distance The
  * `simplify_distance` value works in integer space over a 4096 pixel grid and uses
  * the [Douglas-Peucker algorithm](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm).
  * (used when rendering a vector tile)
- * @param {Object} [options.variables] Mapnik 3.x ONLY: A javascript object 
- * containing key value pairs that should be passed into Mapnik as variables 
- * for rendering and for datasource queries. For example if you passed 
+ * @param {Object} [options.variables] Mapnik 3.x ONLY: A javascript object
+ * containing key value pairs that should be passed into Mapnik as variables
+ * for rendering and for datasource queries. For example if you passed
  * `vtile.render(map,image,{ variables : {zoom:1} },cb)` then the `@zoom`
  * variable would be usable in Mapnik symbolizers like `line-width:"@zoom"`
- * and as a token in Mapnik postgis sql sub-selects like 
+ * and as a token in Mapnik postgis sql sub-selects like
  * `(select * from table where some_field > @zoom)` as tmp (used when rendering a vector tile)
- * @param {Boolean} [options.process_all_rings] if `true`, don't assume winding order and ring order of 
+ * @param {Boolean} [options.process_all_rings] if `true`, don't assume winding order and ring order of
  * polygons are correct according to the [`2.0` Mapbox Vector Tile specification](https://github.com/mapbox/vector-tile-spec)
  * (used when rendering a vector tile)
  * @returns {mapnik.Map} rendered image tile
@@ -1714,7 +1716,7 @@ struct vector_tile_baton_t {
  * var vtile = new mapnik.VectorTile(9,112,195);
  * map.render(vtile, {}, function(err, vtile) {
  *     if (err) throw err;
- *     console.log(vtile); // => vector tile object with data from xml 
+ *     console.log(vtile); // => vector tile object with data from xml
  * });
  */
 NAN_METHOD(Map::render)

--- a/src/mapnik_memory_datasource.cpp
+++ b/src/mapnik_memory_datasource.cpp
@@ -113,7 +113,9 @@ v8::Local<v8::Value> MemoryDatasource::NewInstance(mapnik::datasource_ptr ds_ptr
     MemoryDatasource* d = new MemoryDatasource();
     d->datasource_ = ds_ptr;
     v8::Local<v8::Value> ext = Nan::New<v8::External>(d);
-    return scope.Escape( Nan::New(constructor)->GetFunction()->NewInstance(1, &ext));
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new MemoryDatasource instance");
+    return scope.Escape(maybe_local.ToLocalChecked());
 }
 
 NAN_METHOD(MemoryDatasource::parameters)

--- a/src/mapnik_projection.cpp
+++ b/src/mapnik_projection.cpp
@@ -10,7 +10,7 @@ Nan::Persistent<v8::FunctionTemplate> Projection::constructor;
 
 /**
  * **`mapnik.Projection`**
- * 
+ *
  * A geographical projection: this class makes it possible to translate between
  * locations in different projections
  *
@@ -79,7 +79,7 @@ NAN_METHOD(Projection::New)
             lazy = lazy_opt->BooleanValue();
         }
     }
-            
+
     try
     {
         Projection* p = new Projection(TOSTR(info[0]), lazy);

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -1396,8 +1396,9 @@ NAN_METHOD(VectorTile::layer)
         }
     }
     v8::Local<v8::Value> ext = Nan::New<v8::External>(v);
-    v8::Local<v8::Object> vt_obj = Nan::New(constructor)->GetFunction()->NewInstance(1, &ext);
-    info.GetReturnValue().Set(vt_obj);
+    v8::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Layer instance");
+    else info.GetReturnValue().Set(maybe_local.ToLocalChecked());
     return;
 }
 


### PR DESCRIPTION
The changes in #805 were difficult to read since there were so many formatting changes and node v8 deprecation fixes mixed with mapnik 3.1 changes. So I've ported to a standalone branch here, to test, merge, and then rebase into #805. The goal is to reduce the noise in that branch to help me better review changes related to mapnik 3.1.