### PR TITLE
Fix building against external mapnik that uses mason packages

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -16,16 +16,17 @@ module.exports.paths = {
     'shape_index':   '$(which shapeindex)'
 };
 " > ${MODULE_PATH}/mapnik_settings.js
-# once https://github.com/mapnik/mapnik/pull/3759 is fixed
-# this can be enabled
-#  echo "
-#module.exports.env = {
-#    'ICU_DATA':      '$(mapnik-config --icu-data)',
-#    'GDAL_DATA':     '$(mapnik-config --gdal-data)',
-#    'PROJ_LIB':      '$(mapnik-config --proj-lib)'
-#};
-#" >> ${MODULE_PATH}/mapnik_settings.js
-
+else
+  # If we are using a source install of mapnik (rather than mason package)
+  # then we only dump the mapnik_settings.js and then exit without copying data
+  # Depends on mapnik >= v3.0.16 which includes https://github.com/mapnik/mapnik/pull/3759 is fixed
+  echo "
+module.exports.env = {
+    'ICU_DATA':      '$(mapnik-config --icu-data)',
+    'GDAL_DATA':     '$(mapnik-config --gdal-data)',
+    'PROJ_LIB':      '$(mapnik-config --proj-lib)'
+};
+" > ${MODULE_PATH}/mapnik_settings.js
   exit 0;
 fi
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -6,8 +6,10 @@ MODULE_PATH=./lib/binding
 MAPNIK_SDK=./mason_packages/.link
 
 # Check if we are using Mason's mapnik
+# If not (and we are using a source install of mapnik rather than mason package)
+# then we only dump the mapnik_settings.js and then exit without copying data
 if [[ ! "$(which mapnik-config)" -ef "$MAPNIK_SDK/bin/mapnik-config" ]]; then
-  echo "
+    echo "
 var path = require('path');
 module.exports.paths = {
     'fonts':         '$(mapnik-config --fonts)',
@@ -16,61 +18,61 @@ module.exports.paths = {
     'shape_index':   '$(which shapeindex)'
 };
 " > ${MODULE_PATH}/mapnik_settings.js
-else
-  # If we are using a source install of mapnik (rather than mason package)
-  # then we only dump the mapnik_settings.js and then exit without copying data
-  # Depends on mapnik >= v3.0.16 which includes https://github.com/mapnik/mapnik/pull/3759 is fixed
-  echo "
+      # Depends on mapnik >= v3.0.16 which includes https://github.com/mapnik/mapnik/pull/3759 is fixed
+      echo "
 module.exports.env = {
     'ICU_DATA':      '$(mapnik-config --icu-data)',
     'GDAL_DATA':     '$(mapnik-config --gdal-data)',
     'PROJ_LIB':      '$(mapnik-config --proj-lib)'
 };
 " > ${MODULE_PATH}/mapnik_settings.js
-  exit 0;
-fi
 
-mkdir -p ${MODULE_PATH}/bin/
-
-# the below switch is used since on osx the default cp
-# resolves symlinks automatically with `cp -r`
-# whereas on linux we need to pass `cp -rL`. But the latter
-# command is not supported on OS X. We could upgrade coreutils
-# but ideally we don't depend on more dependencies
-if [[ $(uname -s) == 'Darwin' ]]; then
-    cp ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
-    # copy shapeindex
-    cp ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
-    # copy lib
-    mkdir -p ${MODULE_PATH}/lib/
-    cp ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
-    # copy plugins
-    cp -r ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
-    # copy share data
-    mkdir -p ${MODULE_PATH}/share/gdal
-    cp -L ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
-    cp -r ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
-    mkdir -p ${MODULE_PATH}/share/icu
-    cp -L ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
 else
-    cp -L ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
-    # copy shapeindex
-    cp -L ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
-    # copy lib
-    mkdir -p ${MODULE_PATH}/lib/
-    cp -L ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
-    # copy plugins
-    cp -rL ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
-    # copy share data
-    mkdir -p ${MODULE_PATH}/share/gdal
-    cp -rL ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
-    cp -rL ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
-    mkdir -p ${MODULE_PATH}/share/icu
-    cp -rL ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
-fi
 
-# generate new settings
-echo "
+    # Here we assume we are using the mason mapnik package, and therefore
+    # we copy all the data over to make a portable package.
+
+    mkdir -p ${MODULE_PATH}/bin/
+
+    # the below switch is used since on osx the default cp
+    # resolves symlinks automatically with `cp -r`
+    # whereas on linux we need to pass `cp -rL`. But the latter
+    # command is not supported on OS X. We could upgrade coreutils
+    # but ideally we don't depend on more dependencies
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        cp ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
+        # copy shapeindex
+        cp ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
+        # copy lib
+        mkdir -p ${MODULE_PATH}/lib/
+        cp ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
+        # copy plugins
+        cp -r ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
+        # copy share data
+        mkdir -p ${MODULE_PATH}/share/gdal
+        cp -L ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
+        cp -r ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
+        mkdir -p ${MODULE_PATH}/share/icu
+        cp -L ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
+    else
+        cp -L ${MAPNIK_SDK}/bin/mapnik-index ${MODULE_PATH}/bin/
+        # copy shapeindex
+        cp -L ${MAPNIK_SDK}/bin/shapeindex ${MODULE_PATH}/bin/
+        # copy lib
+        mkdir -p ${MODULE_PATH}/lib/
+        cp -L ${MAPNIK_SDK}/lib/libmapnik.* ${MODULE_PATH}/lib/
+        # copy plugins
+        cp -rL ${MAPNIK_SDK}/lib/mapnik ${MODULE_PATH}/lib/
+        # copy share data
+        mkdir -p ${MODULE_PATH}/share/gdal
+        cp -rL ${MAPNIK_SDK}/share/gdal/*.* ${MODULE_PATH}/share/gdal/
+        cp -rL ${MAPNIK_SDK}/share/proj ${MODULE_PATH}/share/
+        mkdir -p ${MODULE_PATH}/share/icu
+        cp -rL ${MAPNIK_SDK}/share/icu/*/*dat ${MODULE_PATH}/share/icu/
+    fi
+
+    # generate new settings
+    echo "
 var path = require('path');
 module.exports.paths = {
     'fonts': path.join(__dirname, 'lib/mapnik/fonts'),
@@ -84,3 +86,6 @@ module.exports.env = {
     'PROJ_LIB': path.join(__dirname, 'share/proj')
 };
 " > ${MODULE_PATH}/mapnik_settings.js
+
+
+fi


### PR DESCRIPTION
This fixes the ability to build node-mapnik from source against a local mapnik installation where that mapnik installation was build with the `./bootstrap.sh` inside mapnik core. Depends on either mapnik >= 3.0.16 or latest 3.1.x

Refs https://github.com/mapnik/node-mapnik/commit/e6103a7847d29f98243e05dc2160a162fe5dcdb5