### PR TITLE
Keep mason package versions in sync (v3.0.x)

### DIFF
--- a/install_mason.sh
+++ b/install_mason.sh
@@ -25,10 +25,10 @@ if [ ! -f ./mason_packages/.link/bin/mapnik-config ]; then
     install cairo 1.14.8
     install webp 0.6.0
     install libgdal 2.1.3
-    install boost 1.63.0
-    install boost_libsystem 1.63.0
-    install boost_libfilesystem 1.63.0
-    install boost_libregex_icu57 1.63.0
+    install boost 1.65.1
+    install boost_libsystem 1.65.1
+    install boost_libfilesystem 1.65.1
+    install boost_libregex_icu57 1.65.1
     install freetype 2.7.1
     install harfbuzz 1.4.2-ft
 

--- a/test/vector-tile.test.js
+++ b/test/vector-tile.test.js
@@ -2493,7 +2493,7 @@ describe('mapnik.VectorTile ', function() {
                 var simplicityReport = vtile.reportGeometrySimplicity();
                 var validityReport = vtile.reportGeometryValidity();
                 assert.equal(simplicityReport.length, 0);
-                assert.equal(validityReport.length, 1);
+                assert.equal(validityReport.length, 0);
                 assert.equal(vtile.reportGeometryValidity({split_multi_features:true}).length, 0);
             }
             var expected = './test/data/vector_tile/tile0-mpu-true.mvt';


### PR DESCRIPTION
All the dependency versions for mason packages need to match what the original mason package for mapnik builds against. This fixes things for the v3.0.x branch such that the below lists both match:

 - mapnik mason package: https://github.com/mapbox/mason/blob/master/scripts/mapnik/3.0.17/script.sh#L36-L56
 - node-mapnik build: https://github.com/mapnik/node-mapnik/blob/3dc21b5e218b1347fb747de14ed0a4415158f3c6/install_mason.sh
