### PR TITLE
another attemp to fix #835

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ pre_build_check:
 	mapnik-config -v
 
 release_base: pre_build_check deps/geometry/include/mapbox/geometry.hpp node_modules
-	V=1 CXXFLAGS="-fno-omit-frame-pointer $(PROFILING_FLAG)" ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang
+	V=1 CXXFLAGS="-fno-omit-frame-pointer $(PROFILING_FLAG)" ./node_modules/.bin/node-pre-gyp configure build --ENABLE_GLIBC_WORKAROUND=true --loglevel=error --clang
 	@echo "run 'make clean' for full rebuild"
 
 debug_base: pre_build_check deps/geometry/include/mapbox/geometry.hpp node_modules
-	V=1 ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --debug --clang
+	V=1 ./node_modules/.bin/node-pre-gyp configure build --ENABLE_GLIBC_WORKAROUND=true --loglevel=error --debug --clang
 	@echo "run 'make clean' for full rebuild"
 
 release: mason_packages/.link/bin/mapnik-config

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,5 +1,8 @@
 {
   'includes': [ 'common.gypi' ],
+  'variables': {
+      'ENABLE_GLIBC_WORKAROUND%':'false', # can be overriden by a command line variable because of the % sign
+  },
   'targets': [
     {
       'target_name': '<(module_name)',
@@ -46,6 +49,11 @@
           'MAPNIK_GIT_REVISION="<!@(mapnik-config --git-describe)"',
       ],
       'conditions': [
+        ['ENABLE_GLIBC_WORKAROUND != "false"', {
+            'sources': [
+              "src/glibc_workaround.cpp"
+            ]
+        }],
         ['OS=="win"',
           {
             'include_dirs':[

--- a/scripts/check_glibcxx.sh
+++ b/scripts/check_glibcxx.sh
@@ -7,9 +7,9 @@ shopt -s nullglob
 : '
 
 Ensure no GLIBCXX_3.4.2x symbols are present in the binary
-if ENABLE_GLIBC_WORKAROUND is set.
 
-If symbols >= 3.4.20 then it means the binaries would not run on ubuntu trusty without upgrading libstdc++
+If symbols >= 3.4.20 then it returns error code 1. This means
+the binaries would not run on ubuntu trusty without upgrading libstdc++
 
 '
 
@@ -22,9 +22,7 @@ function check() {
         echo "Success: GLIBCXX_3.4.2[0-9] symbols not present in binary (as expected)"
     else
         echo "$(cat /tmp/out.txt | c++filt)"
-        if [[ ${ENABLE_GLIBC_WORKAROUND:-false} == true ]]; then
-            FINAL_RETURN_CODE=1
-        fi
+        FINAL_RETURN_CODE=1
     fi
 }
 

--- a/src/glibc_workaround.cpp
+++ b/src/glibc_workaround.cpp
@@ -1,0 +1,26 @@
+#ifdef __linux__
+
+#ifdef MAPNIK_ENABLE_GLIBC_WORKAROUND
+
+#include <stdexcept>
+
+// https://github.com/bitcoin/bitcoin/pull/4042
+// allows building against libstdc++-dev-4.9 while avoiding
+// GLIBCXX_3.4.20 dep
+// This is needed because libstdc++ itself uses this API - its not
+// just an issue of your code using it, ughhh
+
+namespace std
+{
+
+void __throw_out_of_range_fmt(const char *, ...) __attribute__((__noreturn__));
+void __throw_out_of_range_fmt(const char *err, ...)
+{
+    // Safe and over-simplified version. Ignore the format and print it as-is.
+    __throw_out_of_range(err);
+}
+}
+
+#endif // MAPNIK_ENABLE_GLIBC_WORKAROUND
+
+#endif // __linux__


### PR DESCRIPTION
This solves #835 by applying a workaround (automatically enabled by the `Makefile` wrapper, disabled with a normal source build) that will avoid the `__throw_out_of_range_fmt` symbol dependence creeping into the binary when node-mapnik is compiled and linked against libstdC++-49-dev.

This can be removed when we require libstdc++-5-dev (since I think that will trigger more symbols that are >= 3.4.20 to be depended upon per https://github.com/springmeyer/glibcxx-symbol-versioning).

With this fix applied travis now reports:

```
$ ./scripts/check_glibcxx.sh
checking ./lib/binding/mapnik.node
Success: GLIBCXX_3.4.2[0-9] symbols not present in binary (as expected)
```