### PR TITLE
v3.0.x: add tooling for clang-format/clang-tidy from node-cpp-skel

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+---
+# Mapbox.Variant C/C+ style
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,28 @@
+---
+Checks:          '*'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '\/src\/'
+AnalyzeTemporaryDtors: false
+CheckOptions:    
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ package
 documentation
 mason/
 mason_packages/
+.mason
+local.env
+.toolchain

--- a/.travis.yml
+++ b/.travis.yml
@@ -195,6 +195,32 @@ matrix:
         - curl -S -f https://codecov.io/bash -o codecov
         - chmod +x codecov
         - ./codecov -x "llvm-cov gcov" -Z
+    # Clang format build
+    - os: linux
+      # can be generic since we don't need nodejs to run formatting
+      language: generic
+      env: CLANG_FORMAT
+      # Overrides `install` to avoid initializing clang toolchain
+      install:
+        # Run the clang-format script. Any code formatting changes
+        # will trigger the build to fail (idea here is to get us to pay attention
+        # and get in the habit of running these locally before committing)
+        - make format
+      # Overrides `script`, no need to run tests
+      before_script:
+    # Clang tidy build
+    - os: linux
+      env: CLANG_TIDY
+      node_js: 4
+      # Overrides `install` to avoid initializing clang toolchain
+      install:
+        # First run the clang-tidy target
+        # Any code formatting fixes automatically applied by clang-tidy
+        # will trigger the build to fail (idea here is to get us to pay attention
+        # and get in the habit of running these locally before committing)
+        - make tidy
+      # Overrides `script`, no need to run tests
+      before_script:
 
 notifications:
   slack:

--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,32 @@ debug: mason_packages/.link/bin/mapnik-config
 coverage:
 	./scripts/coverage.sh
 
+tidy:
+	./scripts/clang-tidy.sh
+
+format:
+	./scripts/clang-format.sh
+
+sanitize:
+	./scripts/sanitize.sh
+
 clean:
 	rm -rf lib/binding
 	rm -rf build
 	rm -rf mason
+	# remove remains from running 'make coverage'
+	rm -f *.profraw
+	rm -f *.profdata
 	find test/ -name *actual* -exec rm {} \;
 	echo "run make distclean to also remove mason_packages and node_modules"
 
 distclean: clean
 	rm -rf node_modules
 	rm -rf mason_packages
+	# remove remains from running './scripts/setup.sh'
+	rm -rf .mason
+	rm -rf .toolchain
+	rm -f local.env
 
 xcode: node_modules
 	./node_modules/.bin/node-pre-gyp configure -- -f xcode

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+: '
+
+Runs clang-format on the code in src/
+
+Return `1` if there are files to be formatted, and automatically formats them.
+
+Returns `0` if everything looks properly formatted.
+
+'
+ # Set up the environment by installing mason and clang++
+ # See https://github.com/mapbox/node-cpp-skel/blob/master/docs/extended-tour.md#configuration-files
+./scripts/setup.sh --config local.env
+source local.env
+
+# Add clang-format as a dep
+mason install clang-format ${MASON_LLVM_RELEASE}
+mason link clang-format ${MASON_LLVM_RELEASE}
+
+# Run clang-format on all cpp and hpp files in the /src directory
+find src/ -type f -name '*.hpp' -o -name '*.cpp' \
+ | xargs -I{} clang-format -i -style=file {}
+
+# Print list of modified files
+dirty=$(git ls-files --modified src/)
+
+if [[ $dirty ]]; then
+    echo "The following files have been modified:"
+    echo $dirty
+    git diff
+    exit 1
+else
+    exit 0
+fi

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+# https://clang.llvm.org/extra/clang-tidy/
+
+: '
+
+Runs clang-tidy on the code in src/
+
+Return `1` if there are files automatically fixed by clang-tidy.
+
+Returns `0` if no fixes by clang-tidy.
+
+TODO: should also return non-zero if clang-tidy emits warnings
+or errors about things it cannot automatically fix. However I cannot
+figure out how to get this working yet as it seems that clang-tidy
+always returns 0 even on errors.
+
+'
+
+# to speed up re-runs, only re-create environment if needed
+if [[ ! -f local.env ]]; then
+    # automatically setup environment
+    ./scripts/setup.sh --config local.env
+fi
+
+# source the environment
+source local.env
+
+PATH_TO_CLANG_TIDY_SCRIPT="$(pwd)/mason_packages/.link/share/run-clang-tidy.py"
+
+# to speed up re-runs, only install clang-tidy if needed
+if [[ ! -f PATH_TO_CLANG_TIDY_SCRIPT ]]; then
+    # The MASON_LLVM_RELEASE variable comes from `local.env`
+    mason install clang-tidy ${MASON_LLVM_RELEASE}
+    # We link the tools to make it easy to know ${PATH_TO_CLANG_TIDY_SCRIPT}
+    mason link clang-tidy ${MASON_LLVM_RELEASE}
+fi
+
+# build the compile_commands.json file if it does not exist
+if [[ ! -f build/compile_commands.json ]]; then
+    # We need to clean otherwise when we make the project
+    # will will not see all the compile commands
+    make clean
+    # Create the build directory to put the compile_commands in
+    # We do this first to ensure it is there to start writing to
+    # immediately (make make not create it right away)
+    mkdir -p build
+    # Run make, pipe the output to the generate_compile_commands.py
+    # and drop them in a place that clang-tidy will automatically find them
+    make | scripts/generate_compile_commands.py > build/compile_commands.json
+fi
+
+# change into the build directory so that clang-tidy can find the files
+# at the right paths (since this is where the actual build happens)
+cd build
+${PATH_TO_CLANG_TIDY_SCRIPT} -fix
+cd ../
+
+# Print list of modified files
+dirty=$(git ls-files --modified src/)
+
+if [[ $dirty ]]; then
+    echo "The following files have been modified:"
+    echo $dirty
+    git diff
+    exit 1
+else
+    exit 0
+fi
+

--- a/scripts/generate_compile_commands.py
+++ b/scripts/generate_compile_commands.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import sys
+import json
+import os
+import re
+
+# Script to generate compile_commands.json based on Makefile output
+# Works by accepting Makefile output from stdin, parsing it, and 
+# turning into json records. These are then printed to stdout.
+# More details on the compile_commands format at:
+# https://clang.llvm.org/docs/JSONCompilationDatabase.html
+#
+# Note: make must be run in verbose mode, e.g. V=1 make or VERBOSE=1 make
+#
+# Usage with node-cpp-skel:
+#
+# make | ./scripts/generate_compile_commands.py > build/compile_commands.json
+
+# These work for node-cpp-skel to detect the files being compiled
+# They may need to be modified if you adapt this to another tool
+matcher = re.compile('^(.*) (.+cpp)\n')
+build_dir = os.path.join(os.getcwd(),"build")
+TOKEN_DENOTING_COMPILED_FILE='NODE_GYP_MODULE_NAME'
+
+def generate():
+    compile_commands = []
+    for line in sys.stdin.readlines():
+        if TOKEN_DENOTING_COMPILED_FILE in line:
+            match = matcher.match(line)
+            compile_commands.append({
+                "directory": build_dir,
+                "command": line.strip(),
+                "file": os.path.normpath(os.path.join(build_dir,match.group(2)))
+            })
+    print json.dumps(compile_commands,indent=4)
+
+if __name__ == '__main__':
+    generate()

--- a/scripts/sanitize.sh
+++ b/scripts/sanitize.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+: '
+
+Rebuilds the code with the sanitizers and runs the tests
+
+'
+ # Set up the environment by installing mason and clang++
+ # See https://github.com/mapbox/node-cpp-skel/blob/master/docs/extended-tour.md#configuration-files
+./scripts/setup.sh --config local.env
+source local.env
+make clean
+export CXXFLAGS="${MASON_SANITIZE_CXXFLAGS} ${CXXFLAGS:-}"
+export LDFLAGS="${MASON_SANITIZE_LDFLAGS} ${LDFLAGS:-}"
+make debug
+export ASAN_OPTIONS=fast_unwind_on_malloc=0:${ASAN_OPTIONS}
+if [[ $(uname -s) == 'Darwin' ]]; then
+    # NOTE: we must call node directly here rather than `npm test`
+    # because OS X blocks `DYLD_INSERT_LIBRARIES` being inherited by sub shells
+    # If this is not done right we'll see
+    #   ==18464==ERROR: Interceptors are not working. This may be because AddressSanitizer is loaded too late (e.g. via dlopen).
+    #
+    DYLD_INSERT_LIBRARIES=${MASON_LLVM_RT_PRELOAD} \
+      node node_modules/.bin/tape test/*test.js
+else
+    LD_PRELOAD=${MASON_LLVM_RT_PRELOAD} \
+      npm test
+fi
+

--- a/scripts/sanitize.sh
+++ b/scripts/sanitize.sh
@@ -24,7 +24,7 @@ if [[ $(uname -s) == 'Darwin' ]]; then
     #   ==18464==ERROR: Interceptors are not working. This may be because AddressSanitizer is loaded too late (e.g. via dlopen).
     #
     DYLD_INSERT_LIBRARIES=${MASON_LLVM_RT_PRELOAD} \
-      node node_modules/.bin/tape test/*test.js
+      node node_modules/.bin/_mocha test/*test.js
 else
     LD_PRELOAD=${MASON_LLVM_RT_PRELOAD} \
       npm test

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-8074334}"
+export MASON_RELEASE="${MASON_RELEASE:-eeba3b5}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)
@@ -12,6 +12,8 @@ if [[ ${PLATFORM} == 'darwin' ]]; then
 fi
 
 MASON_URL="https://s3.amazonaws.com/mason-binaries/${PLATFORM}-$(uname -m)"
+
+llvm_toolchain_dir="$(pwd)/.toolchain"
 
 function run() {
     local config=${1}
@@ -35,18 +37,18 @@ function run() {
     GLOBAL_LLVM="${HOME}/.mason/mason_packages/${PLATFORM}-$(uname -m)/llvm/${MASON_LLVM_RELEASE}"
     if [[ -d ${GLOBAL_LLVM} ]]; then
       echo "Detected '${GLOBAL_LLVM}/bin/clang++', using it"
-      local llvm_toolchain=${GLOBAL_LLVM}
+      local llvm_toolchain_dir=${GLOBAL_LLVM}
     elif [[ -d ${GLOBAL_CLANG} ]]; then
       echo "Detected '${GLOBAL_CLANG}/bin/clang++', using it"
-      local llvm_toolchain=${GLOBAL_CLANG}
-    else
+      local llvm_toolchain_dir=${GLOBAL_CLANG}
+    elif [[ -d ${GLOBAL_CLANG} ]]; then
+      echo "Detected '${GLOBAL_CLANG}/bin/clang++', using it"
+      local llvm_toolchain_dir=${GLOBAL_CLANG}
+    elif [[ ! -d ${llvm_toolchain_dir} ]]; then
       BINARY="${MASON_URL}/clang++/${MASON_LLVM_RELEASE}.tar.gz"
-      echo "Did not detect global clang++ at '${GLOBAL_CLANG}' or ${GLOBAL_LLVM}"
       echo "Downloading ${BINARY}"
-      local clang_install_dir="$(pwd)/.toolchain"
-      mkdir -p ${clang_install_dir}
-      curl -sSfL ${BINARY} | tar --gunzip --extract --strip-components=1 --directory=${clang_install_dir}
-      local llvm_toolchain=${clang_install_dir}
+      mkdir -p ${llvm_toolchain_dir}
+      curl -sSfL ${BINARY} | tar --gunzip --extract --strip-components=1 --directory=${llvm_toolchain_dir}
     fi
 
     #
@@ -56,10 +58,8 @@ function run() {
     function setup_mason() {
       local install_dir=${1}
       local mason_release=${2}
-      if [[ ! -d ${install_dir} ]]; then
-          mkdir -p ${install_dir}
-          curl -sSfL https://github.com/mapbox/mason/archive/${mason_release}.tar.gz | tar --gunzip --extract --strip-components=1 --directory=${install_dir}
-      fi
+      mkdir -p ${install_dir}
+      curl -sSfL https://github.com/mapbox/mason/archive/${mason_release}.tar.gz | tar --gunzip --extract --strip-components=1 --directory=${install_dir}
     }
 
     setup_mason $(pwd)/.mason ${MASON_RELEASE}
@@ -68,12 +68,12 @@ function run() {
     # ENV SETTINGS
     #
 
-    echo "export PATH=${llvm_toolchain}/bin:$(pwd)/.mason:$(pwd)/mason_packages/.link/bin:"'${PATH}' > ${config}
-    echo "export CXX=${llvm_toolchain}/bin/clang++" >> ${config}
+    echo "export PATH=${llvm_toolchain_dir}/bin:$(pwd)/.mason:$(pwd)/mason_packages/.link/bin:"'${PATH}' > ${config}
+    echo "export CXX=${CXX:-${llvm_toolchain_dir}/bin/clang++}" >> ${config}
     echo "export MASON_RELEASE=${MASON_RELEASE}" >> ${config}
     echo "export MASON_LLVM_RELEASE=${MASON_LLVM_RELEASE}" >> ${config}
     # https://github.com/google/sanitizers/wiki/AddressSanitizerAsDso
-    RT_BASE=${llvm_toolchain}/lib/clang/${MASON_LLVM_RELEASE}/lib/$(uname | tr A-Z a-z)/libclang_rt
+    RT_BASE=${llvm_toolchain_dir}/lib/clang/${MASON_LLVM_RELEASE}/lib/$(uname | tr A-Z a-z)/libclang_rt
     if [[ $(uname -s) == 'Darwin' ]]; then
         RT_PRELOAD=${RT_BASE}.asan_osx_dynamic.dylib
     else
@@ -85,11 +85,12 @@ function run() {
     echo "leak:v8::internal" >> ${SUPPRESSION_FILE}
     echo "leak:node::CreateEnvironment" >> ${SUPPRESSION_FILE}
     echo "leak:node::Init" >> ${SUPPRESSION_FILE}
-    echo "export ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer)" >> ${config}
+    echo "export ASAN_SYMBOLIZER_PATH=${llvm_toolchain_dir}/bin/llvm-symbolizer" >> ${config}
+    echo "export MSAN_SYMBOLIZER_PATH=${llvm_toolchain_dir}/bin/llvm-symbolizer" >> ${config}
     echo "export UBSAN_OPTIONS=print_stacktrace=1" >> ${config}
     echo "export LSAN_OPTIONS=suppressions=${SUPPRESSION_FILE}" >> ${config}
-    echo "export ASAN_OPTIONS=symbolize=1:abort_on_error=1:detect_container_overflow=1:check_initialization_order=1:detect_stack_use_after_return=1" >> ${config}
-    echo 'export MASON_SANITIZE="-fsanitize=address,undefined -fno-sanitize=vptr,function"' >> ${config}
+    echo "export ASAN_OPTIONS=detect_leaks=1:symbolize=1:abort_on_error=1:detect_container_overflow=1:check_initialization_order=1:detect_stack_use_after_return=1" >> ${config}
+    echo 'export MASON_SANITIZE="-fsanitize=address,undefined,integer,leak -fno-sanitize=vptr,function"' >> ${config}
     echo 'export MASON_SANITIZE_CXXFLAGS="${MASON_SANITIZE} -fno-sanitize=vptr,function -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-common"' >> ${config}
     echo 'export MASON_SANITIZE_LDFLAGS="${MASON_SANITIZE}"' >> ${config}
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${MASON_RELEASE:-eeba3b5}"
+export MASON_RELEASE="${MASON_RELEASE:-acb5245}"
 export MASON_LLVM_RELEASE="${MASON_LLVM_RELEASE:-5.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)

--- a/src/blend.hpp
+++ b/src/blend.hpp
@@ -8,27 +8,26 @@
 #pragma GCC diagnostic pop
 
 // stl
+#include "mapnik_palette.hpp"
+#include "tint.hpp"
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <memory>
-#include "mapnik_palette.hpp"
-#include "tint.hpp"
 
 namespace node_mapnik {
 
 struct BImage {
-    BImage() :
-        data(NULL),
-        dataLength(0),
-        x(0),
-        y(0),
-        width(0),
-        height(0),
-        tint(),
-        im_ptr(nullptr) {}
+    BImage() : data(NULL),
+               dataLength(0),
+               x(0),
+               y(0),
+               width(0),
+               height(0),
+               tint(),
+               im_ptr(nullptr) {}
     Nan::Persistent<v8::Object> buffer;
-    const char * data;
+    const char* data;
     size_t dataLength;
     int x;
     int y;
@@ -73,27 +72,25 @@ struct BlendBaton {
     AlphaMode mode;
     std::ostringstream stream;
 
-    BlendBaton() :
-        quality(0),
-        format(BLEND_FORMAT_PNG),
-        reencode(false),
-        width(0),
-        height(0),
-        matte(0),
-        compression(-1),
-        mode(BLEND_MODE_HEXTREE),
-        stream(std::ios::out | std::ios::binary)
-    {
+    BlendBaton() : quality(0),
+                   format(BLEND_FORMAT_PNG),
+                   reencode(false),
+                   width(0),
+                   height(0),
+                   matte(0),
+                   compression(-1),
+                   mode(BLEND_MODE_HEXTREE),
+                   stream(std::ios::out | std::ios::binary) {
         this->request.data = this;
     }
 
-    ~BlendBaton()
-    {
-        for (auto const& image : images) if (image) image->buffer.Reset();
+    ~BlendBaton() {
+        for (auto const& image : images)
+            if (image) image->buffer.Reset();
         callback.Reset();
     }
 };
 
-}
+} // namespace node_mapnik
 
 #endif // NODE_MAPNIK_BLEND_HPP

--- a/src/ds_emitter.hpp
+++ b/src/ds_emitter.hpp
@@ -9,38 +9,42 @@
 #pragma GCC diagnostic pop
 
 // mapnik
-#include <mapnik/attribute_descriptor.hpp>  // for attribute_descriptor, etc
-#include <mapnik/datasource.hpp>        // for datasource, etc
-#include <mapnik/feature_layer_desc.hpp>  // for layer_descriptor
+#include <mapnik/attribute_descriptor.hpp> // for attribute_descriptor, etc
+#include <mapnik/datasource.hpp>           // for datasource, etc
+#include <mapnik/feature_layer_desc.hpp>   // for layer_descriptor
 
 // node mapnik
 #include "utils.hpp"
 
-
-
 namespace node_mapnik {
 
-static void get_fields(v8::Local<v8::Object> fields, mapnik::datasource_ptr ds)
-{
+static void get_fields(v8::Local<v8::Object> fields, mapnik::datasource_ptr ds) {
     Nan::HandleScope scope;
     mapnik::layer_descriptor ld = ds->get_descriptor();
     // field names and types
     auto const& desc = ld.get_descriptors();
-    for (auto const& attr_info : desc)
-    {
+    for (auto const& attr_info : desc) {
         unsigned field_type = attr_info.get_type();
         std::string type("");
-        if (field_type == mapnik::Integer) type = "Number";
-        else if (field_type == mapnik::Float) type = "Number";
-        else if (field_type == mapnik::Double) type = "Number";
-        else if (field_type == mapnik::String) type = "String";
+        if (field_type == mapnik::Integer)
+            type = "Number";
+        else if (field_type == mapnik::Float)
+            type = "Number";
+        else if (field_type == mapnik::Double)
+            type = "Number";
+        else if (field_type == mapnik::String)
+            type = "String";
         /* LCOV_EXCL_START */
         // Not currently possible to author these values in mapnik core
         // Should likely be considered for removing in mapnik
-        else if (field_type == mapnik::Boolean) type = "Boolean";
-        else if (field_type == mapnik::Geometry) type = "Geometry";
-        else if (field_type == mapnik::Object) type = "Object";
-        else type = "Unknown";
+        else if (field_type == mapnik::Boolean)
+            type = "Boolean";
+        else if (field_type == mapnik::Geometry)
+            type = "Geometry";
+        else if (field_type == mapnik::Object)
+            type = "Object";
+        else
+            type = "Unknown";
         std::string const& name = attr_info.get_name();
         fields->Set(Nan::New<v8::String>(name).ToLocalChecked(), Nan::New<v8::String>(type).ToLocalChecked());
         fields->Set(Nan::New<v8::String>(name).ToLocalChecked(), Nan::New<v8::String>(type).ToLocalChecked());
@@ -48,17 +52,13 @@ static void get_fields(v8::Local<v8::Object> fields, mapnik::datasource_ptr ds)
     }
 }
 
-static void describe_datasource(v8::Local<v8::Object> description, mapnik::datasource_ptr ds)
-{
+static void describe_datasource(v8::Local<v8::Object> description, mapnik::datasource_ptr ds) {
     Nan::HandleScope scope;
-    
+
     // type
-    if (ds->type() == mapnik::datasource::Raster)
-    {
+    if (ds->type() == mapnik::datasource::Raster) {
         description->Set(Nan::New("type").ToLocalChecked(), Nan::New<v8::String>("raster").ToLocalChecked());
-    }
-    else
-    {
+    } else {
         description->Set(Nan::New("type").ToLocalChecked(), Nan::New<v8::String>("vector").ToLocalChecked());
     }
 
@@ -73,52 +73,41 @@ static void describe_datasource(v8::Local<v8::Object> description, mapnik::datas
     description->Set(Nan::New("fields").ToLocalChecked(), fields);
 
     v8::Local<v8::String> js_type = Nan::New<v8::String>("unknown").ToLocalChecked();
-    if (ds->type() == mapnik::datasource::Raster)
-    {
+    if (ds->type() == mapnik::datasource::Raster) {
         js_type = Nan::New<v8::String>("raster").ToLocalChecked();
-    }
-    else
-    {
+    } else {
         boost::optional<mapnik::datasource_geometry_t> geom_type = ds->get_geometry_type();
-        if (geom_type)
-        {
+        if (geom_type) {
             mapnik::datasource_geometry_t g_type = *geom_type;
-            switch (g_type)
-            {
-            case mapnik::datasource_geometry_t::Point:
-            {
+            switch (g_type) {
+            case mapnik::datasource_geometry_t::Point: {
                 js_type = Nan::New<v8::String>("point").ToLocalChecked();
                 break;
             }
-            case mapnik::datasource_geometry_t::LineString:
-            {
+            case mapnik::datasource_geometry_t::LineString: {
                 js_type = Nan::New<v8::String>("linestring").ToLocalChecked();
                 break;
             }
-            case mapnik::datasource_geometry_t::Polygon:
-            {
+            case mapnik::datasource_geometry_t::Polygon: {
                 js_type = Nan::New<v8::String>("polygon").ToLocalChecked();
                 break;
             }
-            case mapnik::datasource_geometry_t::Collection:
-            {
+            case mapnik::datasource_geometry_t::Collection: {
                 js_type = Nan::New<v8::String>("collection").ToLocalChecked();
                 break;
             }
-            default:
-            {
+            default: {
                 break;
             }
             }
         }
     }
     description->Set(Nan::New("geometry_type").ToLocalChecked(), js_type);
-    for (auto const& param : ld.get_extra_parameters()) 
-    {
-        node_mapnik::params_to_object(description,param.first, param.second);
+    for (auto const& param : ld.get_extra_parameters()) {
+        node_mapnik::params_to_object(description, param.first, param.second);
     }
 }
 
-}
+} // namespace node_mapnik
 
 #endif

--- a/src/glibc_workaround.cpp
+++ b/src/glibc_workaround.cpp
@@ -10,16 +10,14 @@
 // This is needed because libstdc++ itself uses this API - its not
 // just an issue of your code using it, ughhh
 
-namespace std
-{
+namespace std {
 
-void __throw_out_of_range_fmt(const char *, ...) __attribute__((__noreturn__));
-void __throw_out_of_range_fmt(const char *err, ...)
-{
+void __throw_out_of_range_fmt(const char*, ...) __attribute__((__noreturn__));
+void __throw_out_of_range_fmt(const char* err, ...) {
     // Safe and over-simplified version. Ignore the format and print it as-is.
     __throw_out_of_range(err);
 }
-}
+} // namespace std
 
 #endif // MAPNIK_ENABLE_GLIBC_WORKAROUND
 

--- a/src/js_grid_utils.hpp
+++ b/src/js_grid_utils.hpp
@@ -2,20 +2,17 @@
 #define __NODE_MAPNIK_GRID_UTILS_H__
 
 // mapnik
+#include <mapnik/feature.hpp>   // for feature_impl, etc
+#include <mapnik/grid/grid.hpp> // for grid
 #include <mapnik/version.hpp>
-#include <mapnik/feature.hpp>           // for feature_impl, etc
-#include <mapnik/grid/grid.hpp>         // for grid
 
 #include "utils.hpp"
 
 // stl
-#include <cmath> // ceil
-#include <stdint.h>  // for uint16_t
+#include <cmath>    // ceil
+#include <stdint.h> // for uint16_t
 
 #include <memory>
-
-
-
 
 namespace node_mapnik {
 
@@ -23,11 +20,10 @@ typedef std::unique_ptr<uint16_t[]> grid_line_type;
 
 template <typename T>
 static void grid2utf(T const& grid_type,
-                     std::vector<grid_line_type> & lines,
+                     std::vector<grid_line_type>& lines,
                      std::vector<typename T::lookup_type>& key_order,
-                     unsigned int resolution)
-{
-    typedef std::map< typename T::lookup_type, typename T::value_type> keys_type;
+                     unsigned int resolution) {
+    typedef std::map<typename T::lookup_type, typename T::value_type> keys_type;
     typedef typename keys_type::const_iterator keys_iterator;
 
     typename T::feature_key_type const& feature_keys = grid_type.get_feature_keys();
@@ -37,42 +33,35 @@ static void grid2utf(T const& grid_type,
     // start counting at utf8 codepoint 32, aka space character
     uint16_t codepoint = 32;
 
-    unsigned array_size = std::ceil(grid_type.width()/static_cast<float>(resolution));
-    for (unsigned y = 0; y < grid_type.height(); y=y+resolution)
-    {
+    unsigned array_size = std::ceil(grid_type.width() / static_cast<float>(resolution));
+    for (unsigned y = 0; y < grid_type.height(); y = y + resolution) {
         uint16_t idx = 0;
         grid_line_type line(new uint16_t[array_size]);
         typename T::value_type const* row = grid_type.get_row(y);
-        for (unsigned x = 0; x < grid_type.width(); x=x+resolution)
-        {
+        for (unsigned x = 0; x < grid_type.width(); x = x + resolution) {
             // todo - this lookup is expensive
             typename T::value_type feature_id = row[x];
             feature_pos = feature_keys.find(feature_id);
-            if (feature_pos != feature_keys.end())
-            {
+            if (feature_pos != feature_keys.end()) {
                 typename T::lookup_type const& val = feature_pos->second;
                 keys_iterator key_pos = keys.find(val);
-                if (key_pos == keys.end())
-                {
+                if (key_pos == keys.end()) {
                     // Create a new entry for this key. Skip the codepoints that
                     // can't be encoded directly in JSON.
-                    if (codepoint == 34) ++codepoint;      // Skip "
-                    else if (codepoint == 92) ++codepoint; // Skip backslash
-                    if (feature_id == mapnik::grid::base_mask)
-                    {
+                    if (codepoint == 34)
+                        ++codepoint; // Skip "
+                    else if (codepoint == 92)
+                        ++codepoint; // Skip backslash
+                    if (feature_id == mapnik::grid::base_mask) {
                         keys[""] = codepoint;
                         key_order.emplace_back("");
-                    }
-                    else
-                    {
+                    } else {
                         keys[val] = codepoint;
                         key_order.push_back(val);
                     }
                     line[idx++] = static_cast<uint16_t>(codepoint);
                     ++codepoint;
-                }
-                else
-                {
+                } else {
                     line[idx++] = static_cast<uint16_t>(key_pos->second);
                 }
             }
@@ -82,58 +71,47 @@ static void grid2utf(T const& grid_type,
     }
 }
 
-
 template <typename T>
 static void write_features(T const& grid_type,
                            v8::Local<v8::Object>& feature_data,
-                           std::vector<typename T::lookup_type> const& key_order)
-{
+                           std::vector<typename T::lookup_type> const& key_order) {
     Nan::HandleScope scope;
     typename T::feature_type const& g_features = grid_type.get_grid_features();
-    if (g_features.size() <= 0)
-    {
+    if (g_features.size() <= 0) {
         return;
     }
     std::set<std::string> const& attributes = grid_type.get_fields();
     typename T::feature_type::const_iterator feat_end = g_features.end();
-    for (std::string const& key_item : key_order)
-    {
-        if (key_item.empty())
-        {
+    for (std::string const& key_item : key_order) {
+        if (key_item.empty()) {
             continue;
         }
 
         typename T::feature_type::const_iterator feat_itr = g_features.find(key_item);
-        if (feat_itr == feat_end)
-        {
+        if (feat_itr == feat_end) {
             continue;
         }
 
         bool found = false;
         v8::Local<v8::Object> feat = Nan::New<v8::Object>();
         mapnik::feature_ptr feature = feat_itr->second;
-        for (std::string const& attr : attributes)
-        {
-            if (attr == "__id__")
-            {
+        for (std::string const& attr : attributes) {
+            if (attr == "__id__") {
                 feat->Set(Nan::New<v8::String>(attr).ToLocalChecked(), Nan::New<v8::Number>(feature->id()));
-            }
-            else if (feature->has_key(attr))
-            {
+            } else if (feature->has_key(attr)) {
                 found = true;
                 mapnik::feature_impl::value_type const& attr_val = feature->get(attr);
                 feat->Set(Nan::New<v8::String>(attr).ToLocalChecked(),
-                    mapnik::util::apply_visitor(node_mapnik::value_converter(),
-                    attr_val));
+                          mapnik::util::apply_visitor(node_mapnik::value_converter(),
+                                                      attr_val));
             }
         }
 
-        if (found)
-        {
+        if (found) {
             feature_data->Set(Nan::New<v8::String>(feat_itr->first).ToLocalChecked(), feat);
         }
     }
 }
 
-}
+} // namespace node_mapnik
 #endif // __NODE_MAPNIK_GRID_UTILS_H__

--- a/src/mapnik_cairo_surface.cpp
+++ b/src/mapnik_cairo_surface.cpp
@@ -1,6 +1,5 @@
-#include "utils.hpp"
 #include "mapnik_cairo_surface.hpp"
-
+#include "utils.hpp"
 
 Nan::Persistent<v8::FunctionTemplate> CairoSurface::constructor;
 
@@ -17,50 +16,41 @@ void CairoSurface::Initialize(v8::Local<v8::Object> target) {
     constructor.Reset(lcons);
 }
 
-CairoSurface::CairoSurface(std::string const& format, unsigned int width, unsigned int height) :
-    Nan::ObjectWrap(),
-    ss_(),
-    width_(width),
-    height_(height),
-    format_(format)
-{
+CairoSurface::CairoSurface(std::string const& format, unsigned int width, unsigned int height) : Nan::ObjectWrap(),
+                                                                                                 ss_(),
+                                                                                                 width_(width),
+                                                                                                 height_(height),
+                                                                                                 format_(format) {
 }
 
-CairoSurface::~CairoSurface()
-{
+CairoSurface::~CairoSurface() {
 }
 
-NAN_METHOD(CairoSurface::New)
-{
-    if (!info.IsConstructCall())
-    {
+NAN_METHOD(CairoSurface::New) {
+    if (!info.IsConstructCall()) {
         Nan::ThrowError("Cannot call constructor as function, you need to use 'new' keyword");
         return;
     }
 
-    if (info[0]->IsExternal())
-    {
+    if (info[0]->IsExternal()) {
         // Currently there is no C++ that executes this call
         /* LCOV_EXCL_START */
         v8::Local<v8::External> ext = info[0].As<v8::External>();
         void* ptr = ext->Value();
-        CairoSurface* im =  static_cast<CairoSurface*>(ptr);
+        CairoSurface* im = static_cast<CairoSurface*>(ptr);
         im->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
         /* LCOV_EXCL_STOP */
     }
 
-    if (info.Length() == 3)
-    {
-        if (!info[0]->IsString())
-        {
+    if (info.Length() == 3) {
+        if (!info[0]->IsString()) {
             Nan::ThrowTypeError("CairoSurface 'format' must be a string");
             return;
         }
         std::string format = TOSTR(info[0]);
-        if (!info[1]->IsNumber() || !info[2]->IsNumber())
-        {
+        if (!info[1]->IsNumber() || !info[2]->IsNumber()) {
             Nan::ThrowTypeError("CairoSurface 'width' and 'height' must be a integers");
             return;
         }
@@ -68,29 +58,24 @@ NAN_METHOD(CairoSurface::New)
         im->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
-    }
-    else
-    {
+    } else {
         Nan::ThrowError("CairoSurface requires three arguments: format, width, and height");
         return;
     }
     return;
 }
 
-NAN_METHOD(CairoSurface::width)
-{
+NAN_METHOD(CairoSurface::width) {
     CairoSurface* im = Nan::ObjectWrap::Unwrap<CairoSurface>(info.Holder());
     info.GetReturnValue().Set(Nan::New(im->width()));
 }
 
-NAN_METHOD(CairoSurface::height)
-{
+NAN_METHOD(CairoSurface::height) {
     CairoSurface* im = Nan::ObjectWrap::Unwrap<CairoSurface>(info.Holder());
     info.GetReturnValue().Set(Nan::New(im->height()));
 }
 
-NAN_METHOD(CairoSurface::getData)
-{
+NAN_METHOD(CairoSurface::getData) {
     CairoSurface* surface = Nan::ObjectWrap::Unwrap<CairoSurface>(info.Holder());
     std::string s = surface->ss_.str();
     info.GetReturnValue().Set(Nan::CopyBuffer((char*)s.data(), s.size()).ToLocalChecked());

--- a/src/mapnik_cairo_surface.hpp
+++ b/src/mapnik_cairo_surface.hpp
@@ -7,8 +7,8 @@
 #include <nan.h>
 #pragma GCC diagnostic pop
 
-#include <string>
 #include <sstream>
+#include <string>
 
 // cairo
 #if defined(HAVE_CAIRO)
@@ -17,10 +17,8 @@
 #define cairo_status_t int
 #endif
 
-
-
-class CairoSurface: public Nan::ObjectWrap {
-public:
+class CairoSurface : public Nan::ObjectWrap {
+  public:
     typedef std::stringstream i_stream;
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
@@ -31,13 +29,11 @@ public:
     void _ref() { Ref(); }
     void _unref() { Unref(); }
     CairoSurface(std::string const& format, unsigned int width, unsigned int height);
-    static cairo_status_t write_callback(void *closure,
-                                         const unsigned char *data,
-                                         unsigned int length)
-    {
+    static cairo_status_t write_callback(void* closure,
+                                         const unsigned char* data,
+                                         unsigned int length) {
 #if defined(HAVE_CAIRO)
-        if (!closure)
-        {
+        if (!closure) {
             // Since the closure here is the passing of the std::stringstream "i_stream" of this
             // class it is unlikely that this could ever be reached unless something was very wrong
             // and went out of scope, aka it was improperly programmed. Therefore, it is not possible
@@ -47,7 +43,7 @@ public:
             /* LCOV_EXCL_STOP */
         }
         i_stream* fin = reinterpret_cast<i_stream*>(closure);
-        *fin << std::string((const char*)data,(size_t)length);
+        *fin << std::string((const char*)data, (size_t)length);
         return CAIRO_STATUS_SUCCESS;
 #else
         return 11; // CAIRO_STATUS_WRITE_ERROR
@@ -56,7 +52,8 @@ public:
     unsigned width() { return width_; }
     unsigned height() { return height_; }
     mutable i_stream ss_;
-private:
+
+  private:
     unsigned width_;
     unsigned height_;
     std::string format_;

--- a/src/mapnik_color.cpp
+++ b/src/mapnik_color.cpp
@@ -1,12 +1,12 @@
 #include "mapnik_color.hpp"
 
-#include "utils.hpp"                    // for ATTR, TOSTR
+#include "utils.hpp" // for ATTR, TOSTR
 
 // mapnik
-#include <mapnik/color.hpp>             // for color
+#include <mapnik/color.hpp> // for color
 
 // stl
-#include <exception>                    // for exception
+#include <exception> // for exception
 
 Nan::Persistent<v8::FunctionTemplate> Color::constructor;
 
@@ -52,24 +52,19 @@ void Color::Initialize(v8::Local<v8::Object> target) {
     constructor.Reset(lcons);
 }
 
-Color::Color() :
-    Nan::ObjectWrap(),
-    this_() {}
+Color::Color() : Nan::ObjectWrap(),
+                 this_() {}
 
-Color::~Color()
-{
+Color::~Color() {
 }
 
-NAN_METHOD(Color::New)
-{
-    if (!info.IsConstructCall())
-    {
+NAN_METHOD(Color::New) {
+    if (!info.IsConstructCall()) {
         Nan::ThrowError("Cannot call constructor as function, you need to use 'new' keyword");
         return;
     }
 
-    if (info[0]->IsExternal())
-    {
+    if (info[0]->IsExternal()) {
         v8::Local<v8::External> ext = info[0].As<v8::External>();
         void* ptr = ext->Value();
         Color* c = static_cast<Color*>(ptr);
@@ -79,95 +74,75 @@ NAN_METHOD(Color::New)
     }
 
     color_ptr c_p;
-    try
-    {
+    try {
         if (info.Length() == 1 &&
-            info[0]->IsString())
-        {
+            info[0]->IsString()) {
             c_p = std::make_shared<mapnik::color>(TOSTR(info[0]));
-        }
-        else if (info.Length() == 2 &&
-                 info[0]->IsString() &&
-                 info[1]->IsBoolean())
-        {
-            c_p = std::make_shared<mapnik::color>(TOSTR(info[0]),info[1]->BooleanValue());
-        }
-        else if (info.Length() == 3 &&
-                 info[0]->IsNumber() &&
-                 info[1]->IsNumber() &&
-                 info[2]->IsNumber())
-        {
+        } else if (info.Length() == 2 &&
+                   info[0]->IsString() &&
+                   info[1]->IsBoolean()) {
+            c_p = std::make_shared<mapnik::color>(TOSTR(info[0]), info[1]->BooleanValue());
+        } else if (info.Length() == 3 &&
+                   info[0]->IsNumber() &&
+                   info[1]->IsNumber() &&
+                   info[2]->IsNumber()) {
             int r = info[0]->IntegerValue();
             int g = info[1]->IntegerValue();
             int b = info[2]->IntegerValue();
-            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255)
-            {
+            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) {
                 Nan::ThrowTypeError("color value out of range");
                 return;
             }
-            c_p = std::make_shared<mapnik::color>(r,g,b);
-        }
-        else if (info.Length() == 4 &&
-                 info[0]->IsNumber() &&
-                 info[1]->IsNumber() &&
-                 info[2]->IsNumber() &&
-                 info[3]->IsBoolean())
-        {
+            c_p = std::make_shared<mapnik::color>(r, g, b);
+        } else if (info.Length() == 4 &&
+                   info[0]->IsNumber() &&
+                   info[1]->IsNumber() &&
+                   info[2]->IsNumber() &&
+                   info[3]->IsBoolean()) {
             int r = info[0]->IntegerValue();
             int g = info[1]->IntegerValue();
             int b = info[2]->IntegerValue();
-            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255)
-            {
+            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) {
                 Nan::ThrowTypeError("color value out of range");
                 return;
             }
-            c_p = std::make_shared<mapnik::color>(r,g,b,255,info[3]->BooleanValue());
-        }
-        else if (info.Length() == 4 &&
-                 info[0]->IsNumber() &&
-                 info[1]->IsNumber() &&
-                 info[2]->IsNumber() &&
-                 info[3]->IsNumber())
-        {
+            c_p = std::make_shared<mapnik::color>(r, g, b, 255, info[3]->BooleanValue());
+        } else if (info.Length() == 4 &&
+                   info[0]->IsNumber() &&
+                   info[1]->IsNumber() &&
+                   info[2]->IsNumber() &&
+                   info[3]->IsNumber()) {
             int r = info[0]->IntegerValue();
             int g = info[1]->IntegerValue();
             int b = info[2]->IntegerValue();
             int a = info[3]->IntegerValue();
-            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 || a < 0 || a > 255)
-            {
+            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 || a < 0 || a > 255) {
                 Nan::ThrowTypeError("color value out of range");
                 return;
             }
-            c_p = std::make_shared<mapnik::color>(r,g,b,a);
-        }
-        else if (info.Length() == 5 &&
-                 info[0]->IsNumber() &&
-                 info[1]->IsNumber() &&
-                 info[2]->IsNumber() &&
-                 info[3]->IsNumber() &&
-                 info[4]->IsBoolean())
-        {
+            c_p = std::make_shared<mapnik::color>(r, g, b, a);
+        } else if (info.Length() == 5 &&
+                   info[0]->IsNumber() &&
+                   info[1]->IsNumber() &&
+                   info[2]->IsNumber() &&
+                   info[3]->IsNumber() &&
+                   info[4]->IsBoolean()) {
             int r = info[0]->IntegerValue();
             int g = info[1]->IntegerValue();
             int b = info[2]->IntegerValue();
             int a = info[3]->IntegerValue();
-            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 || a < 0 || a > 255)
-            {
+            if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 || a < 0 || a > 255) {
                 Nan::ThrowTypeError("color value out of range");
                 return;
             }
-            c_p = std::make_shared<mapnik::color>(r,g,b,a,info[4]->BooleanValue());
-        }
-        else
-        {
+            c_p = std::make_shared<mapnik::color>(r, g, b, a, info[4]->BooleanValue());
+        } else {
             Nan::ThrowTypeError("invalid arguments: colors can be created from a string, integer r,g,b values, or integer r,g,b,a values");
             return;
         }
         // todo allow int,int,int and int,int,int,int contructor
 
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         Nan::ThrowError(ex.what());
         return;
     }
@@ -188,8 +163,7 @@ v8::Local<v8::Value> Color::NewInstance(mapnik::color const& color) {
     return scope.Escape(maybe_local.ToLocalChecked());
 }
 
-NAN_GETTER(Color::get_prop)
-{
+NAN_GETTER(Color::get_prop) {
     Color* c = Nan::ObjectWrap::Unwrap<Color>(info.Holder());
     std::string a = TOSTR(property);
     if (a == "a")
@@ -202,18 +176,15 @@ NAN_GETTER(Color::get_prop)
         info.GetReturnValue().Set(Nan::New<v8::Integer>(c->get()->blue()));
 }
 
-NAN_SETTER(Color::set_prop)
-{
+NAN_SETTER(Color::set_prop) {
     Color* c = Nan::ObjectWrap::Unwrap<Color>(info.Holder());
     std::string a = TOSTR(property);
-    if (!value->IsNumber())
-    {
+    if (!value->IsNumber()) {
         Nan::ThrowTypeError("color channel value must be an integer");
         return;
     }
     int val = value->IntegerValue();
-    if (val < 0 || val > 255)
-    {
+    if (val < 0 || val > 255) {
         Nan::ThrowTypeError("Value out of range for color channel");
         return;
     }
@@ -228,7 +199,6 @@ NAN_SETTER(Color::set_prop)
     }
 }
 
-
 /**
  * Get whether this color is premultiplied
  *
@@ -237,8 +207,7 @@ NAN_SETTER(Color::set_prop)
  * @instance
  * @returns {boolean} premultiplied
  */
-NAN_GETTER(Color::get_premultiplied)
-{
+NAN_GETTER(Color::get_premultiplied) {
     Color* c = Nan::ObjectWrap::Unwrap<Color>(info.Holder());
     info.GetReturnValue().Set(Nan::New<v8::Boolean>(c->get()->get_premultiplied()));
     return;
@@ -256,11 +225,9 @@ NAN_GETTER(Color::get_premultiplied)
  * c.set_premultiplied(true);
  * @throws {TypeError} given a non-boolean argument
  */
-NAN_SETTER(Color::set_premultiplied)
-{
+NAN_SETTER(Color::set_premultiplied) {
     Color* c = Nan::ObjectWrap::Unwrap<Color>(info.Holder());
-    if (!value->IsBoolean())
-    {
+    if (!value->IsBoolean()) {
         Nan::ThrowTypeError("Value set to premultiplied must be a boolean");
         return;
     }
@@ -279,8 +246,7 @@ NAN_SETTER(Color::set_premultiplied)
  * green.toString()
  * // 'rgb(0,128,0)'
  */
-NAN_METHOD(Color::toString)
-{
+NAN_METHOD(Color::toString) {
     Color* c = Nan::ObjectWrap::Unwrap<Color>(info.Holder());
     info.GetReturnValue().Set(Nan::New<v8::String>(c->get()->to_string()).ToLocalChecked());
 }
@@ -297,8 +263,7 @@ NAN_METHOD(Color::toString)
  * c.hex();
  * // '#008000'
  */
-NAN_METHOD(Color::hex)
-{
+NAN_METHOD(Color::hex) {
     Color* c = Nan::ObjectWrap::Unwrap<Color>(info.Holder());
     std::string hex = c->get()->to_hex_string();
     info.GetReturnValue().Set(Nan::New<v8::String>(hex).ToLocalChecked());

--- a/src/mapnik_color.hpp
+++ b/src/mapnik_color.hpp
@@ -9,13 +9,13 @@
 
 #include <memory>
 
-
-
-namespace mapnik { class color; }
+namespace mapnik {
+class color;
+}
 typedef std::shared_ptr<mapnik::color> color_ptr;
 
-class Color: public Nan::ObjectWrap {
-public:
+class Color : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -30,7 +30,7 @@ public:
     Color();
     inline color_ptr get() { return this_; }
 
-private:
+  private:
     ~Color();
     color_ptr this_;
 };

--- a/src/mapnik_datasource.hpp
+++ b/src/mapnik_datasource.hpp
@@ -9,14 +9,14 @@
 
 #include <memory>
 
-
-
-namespace mapnik { class datasource; }
+namespace mapnik {
+class datasource;
+}
 
 typedef std::shared_ptr<mapnik::datasource> datasource_ptr;
 
-class Datasource: public Nan::ObjectWrap {
-public:
+class Datasource : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -31,7 +31,7 @@ public:
     Datasource();
     inline datasource_ptr get() { return datasource_; }
 
-private:
+  private:
     ~Datasource();
     datasource_ptr datasource_;
 };

--- a/src/mapnik_expression.hpp
+++ b/src/mapnik_expression.hpp
@@ -12,10 +12,8 @@
 // mapnik
 #include <mapnik/expression.hpp>
 
-
-
-class Expression: public Nan::ObjectWrap {
-public:
+class Expression : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -25,7 +23,7 @@ public:
     Expression();
     inline mapnik::expression_ptr get() { return this_; }
 
-private:
+  private:
     ~Expression();
     mapnik::expression_ptr this_;
 };

--- a/src/mapnik_feature.hpp
+++ b/src/mapnik_feature.hpp
@@ -10,13 +10,11 @@
 #include <memory>
 
 // mapnik
-#include <mapnik/version.hpp>
 #include <mapnik/feature.hpp>
+#include <mapnik/version.hpp>
 
-
-
-class Feature: public Nan::ObjectWrap {
-public:
+class Feature : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -35,7 +33,7 @@ public:
     Feature(int id);
     inline mapnik::feature_ptr get() { return this_; }
 
-private:
+  private:
     ~Feature();
     mapnik::feature_ptr this_;
     mapnik::context_ptr ctx_;

--- a/src/mapnik_featureset.cpp
+++ b/src/mapnik_featureset.cpp
@@ -24,27 +24,22 @@ void Featureset::Initialize(v8::Local<v8::Object> target) {
     constructor.Reset(lcons);
 }
 
-Featureset::Featureset() :
-    Nan::ObjectWrap(),
-    this_() {}
+Featureset::Featureset() : Nan::ObjectWrap(),
+                           this_() {}
 
-Featureset::~Featureset()
-{
+Featureset::~Featureset() {
 }
 
-NAN_METHOD(Featureset::New)
-{
-    if (!info.IsConstructCall())
-    {
+NAN_METHOD(Featureset::New) {
+    if (!info.IsConstructCall()) {
         Nan::ThrowError("Cannot call constructor as function, you need to use 'new' keyword");
         return;
     }
 
-    if (info[0]->IsExternal())
-    {
+    if (info[0]->IsExternal()) {
         v8::Local<v8::External> ext = info[0].As<v8::External>();
         void* ptr = ext->Value();
-        Featureset* fs =  static_cast<Featureset*>(ptr);
+        Featureset* fs = static_cast<Featureset*>(ptr);
         fs->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
@@ -63,17 +58,13 @@ NAN_METHOD(Featureset::New)
  * @memberof Featureset
  * @returns {mapnik.Feature|null} next feature
  */
-NAN_METHOD(Featureset::next)
-{
+NAN_METHOD(Featureset::next) {
     Featureset* fs = Nan::ObjectWrap::Unwrap<Featureset>(info.Holder());
     if (fs->this_) {
         mapnik::feature_ptr fp;
-        try
-        {
+        try {
             fp = fs->this_->next();
-        }
-        catch (std::exception const& ex)
-        {
+        } catch (std::exception const& ex) {
             // It is not immediately obvious how this could cause an exception, a check of featureset plugin
             // implementations resulted in no obvious way that an exception could be raised. Therefore, it
             // is not obvious currently what could raise this exception. However, since a plugin could possibly
@@ -92,8 +83,7 @@ NAN_METHOD(Featureset::next)
     return;
 }
 
-v8::Local<v8::Value> Featureset::NewInstance(mapnik::featureset_ptr fsp)
-{
+v8::Local<v8::Value> Featureset::NewInstance(mapnik::featureset_ptr fsp) {
     Nan::EscapableHandleScope scope;
     Featureset* fs = new Featureset();
     fs->this_ = fsp;

--- a/src/mapnik_featureset.hpp
+++ b/src/mapnik_featureset.hpp
@@ -10,12 +10,10 @@
 #include <mapnik/featureset.hpp>
 #include <memory>
 
-
-
 typedef mapnik::featureset_ptr fs_ptr;
 
-class Featureset: public Nan::ObjectWrap {
-public:
+class Featureset : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -24,7 +22,7 @@ public:
 
     Featureset();
 
-private:
+  private:
     ~Featureset();
     fs_ptr this_;
 };

--- a/src/mapnik_fonts.hpp
+++ b/src/mapnik_fonts.hpp
@@ -1,7 +1,6 @@
 #ifndef __NODE_MAPNIK_FONTS_H__
 #define __NODE_MAPNIK_FONTS_H__
 
-
 // mapnik
 #include <mapnik/font_engine_freetype.hpp>
 
@@ -10,16 +9,11 @@
 
 #include "utils.hpp"
 
-
-
 namespace node_mapnik {
 
-static inline NAN_METHOD(register_fonts)
-{
-    try
-    {
-        if (info.Length() == 0 || !info[0]->IsString())
-        {
+static inline NAN_METHOD(register_fonts) {
+    try {
+        if (info.Length() == 0 || !info[0]->IsString()) {
             Nan::ThrowTypeError("first argument must be a path to a directory of fonts");
             return;
         }
@@ -27,39 +21,31 @@ static inline NAN_METHOD(register_fonts)
         bool found = false;
 
         // option hash
-        if (info.Length() >= 2)
-        {
-            if (!info[1]->IsObject())
-            {
+        if (info.Length() >= 2) {
+            if (!info[1]->IsObject()) {
                 Nan::ThrowTypeError("second argument is optional, but if provided must be an object, eg. { recurse: true }");
                 return;
             }
 
             v8::Local<v8::Object> options = info[1].As<v8::Object>();
-            if (options->Has(Nan::New("recurse").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("recurse").ToLocalChecked())) {
                 v8::Local<v8::Value> recurse_opt = options->Get(Nan::New("recurse").ToLocalChecked());
-                if (!recurse_opt->IsBoolean())
-                {
+                if (!recurse_opt->IsBoolean()) {
                     Nan::ThrowTypeError("'recurse' must be a Boolean");
                     return;
                 }
 
                 bool recurse = recurse_opt->BooleanValue();
                 std::string path = TOSTR(info[0]);
-                found = mapnik::freetype_engine::register_fonts(path,recurse);
+                found = mapnik::freetype_engine::register_fonts(path, recurse);
             }
-        }
-        else
-        {
+        } else {
             std::string path = TOSTR(info[0]);
             found = mapnik::freetype_engine::register_fonts(path);
         }
 
         info.GetReturnValue().Set(Nan::New(found));
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         // Does not appear that this line can ever be reached, not certain what would ever throw an exception
         /* LCOV_EXCL_START */
         Nan::ThrowError(ex.what());
@@ -68,41 +54,34 @@ static inline NAN_METHOD(register_fonts)
     }
 }
 
-static inline NAN_METHOD(available_font_faces)
-{
+static inline NAN_METHOD(available_font_faces) {
     auto const& names = mapnik::freetype_engine::face_names();
     v8::Local<v8::Array> a = Nan::New<v8::Array>(names.size());
-    for (unsigned i = 0; i < names.size(); ++i)
-    {
+    for (unsigned i = 0; i < names.size(); ++i) {
         a->Set(i, Nan::New<v8::String>(names[i].c_str()).ToLocalChecked());
     }
     info.GetReturnValue().Set(a);
 }
 
-static inline NAN_METHOD(memory_fonts)
-{
+static inline NAN_METHOD(memory_fonts) {
     auto const& font_cache = mapnik::freetype_engine::get_cache();
     v8::Local<v8::Array> a = Nan::New<v8::Array>(font_cache.size());
     unsigned i = 0;
-    for (auto const& kv : font_cache)
-    {
+    for (auto const& kv : font_cache) {
         a->Set(i++, Nan::New<v8::String>(kv.first.c_str()).ToLocalChecked());
     }
     info.GetReturnValue().Set(a);
 }
 
-static inline NAN_METHOD(available_font_files)
-{
+static inline NAN_METHOD(available_font_files) {
     auto const& mapping = mapnik::freetype_engine::get_mapping();
     v8::Local<v8::Object> obj = Nan::New<v8::Object>();
-    for (auto const& kv : mapping)
-    {
+    for (auto const& kv : mapping) {
         obj->Set(Nan::New<v8::String>(kv.first.c_str()).ToLocalChecked(), Nan::New<v8::String>(kv.second.second.c_str()).ToLocalChecked());
     }
     info.GetReturnValue().Set(obj);
 }
 
-
-}
+} // namespace node_mapnik
 
 #endif // __NODE_MAPNIK_FONTS_H__

--- a/src/mapnik_geometry.hpp
+++ b/src/mapnik_geometry.hpp
@@ -10,10 +10,8 @@
 // mapnik
 #include <mapnik/feature.hpp>
 
-
-
-class Geometry: public Nan::ObjectWrap {
-public:
+class Geometry : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -28,7 +26,8 @@ public:
     static void to_json(uv_work_t* req);
     static void after_to_json(uv_work_t* req);
     Geometry(mapnik::feature_ptr f);
-private:
+
+  private:
     ~Geometry();
     mapnik::feature_ptr feat_;
 };

--- a/src/mapnik_grid.hpp
+++ b/src/mapnik_grid.hpp
@@ -12,12 +12,10 @@
 #include <mapnik/grid/grid.hpp>
 #include <memory>
 
-
-
 typedef std::shared_ptr<mapnik::grid> grid_ptr;
 
-class Grid: public Nan::ObjectWrap {
-public:
+class Grid : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -47,7 +45,7 @@ public:
     Grid(unsigned int width, unsigned int height, std::string const& key);
     inline grid_ptr get() { return this_; }
 
-private:
+  private:
     ~Grid();
     grid_ptr this_;
 };

--- a/src/mapnik_grid_view.hpp
+++ b/src/mapnik_grid_view.hpp
@@ -14,16 +14,15 @@
 
 class Grid;
 
-
 typedef std::shared_ptr<mapnik::grid_view> grid_view_ptr;
 
-class GridView: public Nan::ObjectWrap {
-public:
+class GridView : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
-    static v8::Local<v8::Value> NewInstance(Grid * JSGrid,
-                             unsigned x,unsigned y, unsigned w, unsigned h);
+    static v8::Local<v8::Value> NewInstance(Grid* JSGrid,
+                                            unsigned x, unsigned y, unsigned w, unsigned h);
 
     static NAN_METHOD(encodeSync);
     static NAN_METHOD(encode);
@@ -40,13 +39,13 @@ public:
     static NAN_METHOD(isSolidSync);
     static NAN_METHOD(getPixel);
 
-    GridView(Grid * JSGrid);
+    GridView(Grid* JSGrid);
     inline grid_view_ptr get() { return this_; }
 
-private:
+  private:
     ~GridView();
     grid_view_ptr this_;
-    Grid * JSGrid_;
+    Grid* JSGrid_;
 };
 
 #endif

--- a/src/mapnik_image.hpp
+++ b/src/mapnik_image.hpp
@@ -9,17 +9,15 @@
 
 #include <memory>
 
-
-
-namespace mapnik { 
-    struct image_any; 
-    enum image_dtype : std::uint8_t;
-}
+namespace mapnik {
+struct image_any;
+enum image_dtype : std::uint8_t;
+} // namespace mapnik
 
 typedef std::shared_ptr<mapnik::image_any> image_ptr;
 
-class Image: public Nan::ObjectWrap {
-public:
+class Image : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -108,7 +106,7 @@ public:
     static v8::Local<v8::Value> _resizeSync(Nan::NAN_METHOD_ARGS_TYPE info);
     static NAN_METHOD(resizeSync);
     static NAN_METHOD(data);
-    
+
     static NAN_GETTER(get_scaling);
     static NAN_SETTER(set_scaling);
     static NAN_GETTER(get_offset);
@@ -121,7 +119,7 @@ public:
     Image(image_ptr this_);
     inline image_ptr get() { return this_; }
 
-private:
+  private:
     ~Image();
     image_ptr this_;
 };

--- a/src/mapnik_image_view.hpp
+++ b/src/mapnik_image_view.hpp
@@ -7,24 +7,25 @@
 #include <nan.h>
 #pragma GCC diagnostic pop
 
-#include <mapnik/image.hpp>        // for image_rgba8
+#include <mapnik/image.hpp> // for image_rgba8
 #include <mapnik/image_view_any.hpp>
 #include <memory>
 
 class Image;
-namespace mapnik { template <typename T> class image_view; }
-
-
+namespace mapnik {
+template <typename T>
+class image_view;
+}
 
 typedef std::shared_ptr<mapnik::image_view_any> image_view_ptr;
 
-class ImageView: public Nan::ObjectWrap {
-public:
+class ImageView : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
-    static v8::Local<v8::Value> NewInstance(Image * JSImage,
-                             unsigned x,unsigned y, unsigned w, unsigned h);
+    static v8::Local<v8::Value> NewInstance(Image* JSImage,
+                                            unsigned x, unsigned y, unsigned w, unsigned h);
 
     static NAN_METHOD(encodeSync);
     static NAN_METHOD(encode);
@@ -43,12 +44,12 @@ public:
     static NAN_METHOD(isSolidSync);
     static NAN_METHOD(getPixel);
 
-    ImageView(Image * JSImage);
+    ImageView(Image* JSImage);
 
-private:
+  private:
     ~ImageView();
     image_view_ptr this_;
-    Image * JSImage_;
+    Image* JSImage_;
 };
 
 #endif

--- a/src/mapnik_layer.cpp
+++ b/src/mapnik_layer.cpp
@@ -1,14 +1,14 @@
 #include "mapnik_layer.hpp"
 
-#include "utils.hpp"                    // for TOSTR, ATTR, etc
+#include "utils.hpp" // for TOSTR, ATTR, etc
 
 #include "mapnik_datasource.hpp"
 #include "mapnik_memory_datasource.hpp"
 
 // mapnik
 #include <mapnik/datasource.hpp>        // for datasource_ptr, datasource
-#include <mapnik/memory_datasource.hpp> // for memory_datasource
 #include <mapnik/layer.hpp>             // for layer
+#include <mapnik/memory_datasource.hpp> // for memory_datasource
 #include <mapnik/params.hpp>            // for parameters
 
 // stl
@@ -38,46 +38,38 @@ void Layer::Initialize(v8::Local<v8::Object> target) {
     ATTR(lcons, "queryable", get_prop, set_prop);
     ATTR(lcons, "clear_label_cache", get_prop, set_prop);
 
-    target->Set(Nan::New("Layer").ToLocalChecked(),lcons->GetFunction());
+    target->Set(Nan::New("Layer").ToLocalChecked(), lcons->GetFunction());
     constructor.Reset(lcons);
 }
 
-Layer::Layer(std::string const& name):
-    Nan::ObjectWrap(),
-    layer_(std::make_shared<mapnik::layer>(name)) {}
+Layer::Layer(std::string const& name) : Nan::ObjectWrap(),
+                                        layer_(std::make_shared<mapnik::layer>(name)) {}
 
-Layer::Layer(std::string const& name, std::string const& srs):
-    Nan::ObjectWrap(),
-    layer_(std::make_shared<mapnik::layer>(name,srs)) {}
+Layer::Layer(std::string const& name, std::string const& srs) : Nan::ObjectWrap(),
+                                                                layer_(std::make_shared<mapnik::layer>(name, srs)) {}
 
-Layer::Layer():
-    Nan::ObjectWrap(),
-    layer_() {}
-
+Layer::Layer() : Nan::ObjectWrap(),
+                 layer_() {}
 
 Layer::~Layer() {}
 
-NAN_METHOD(Layer::New)
-{
+NAN_METHOD(Layer::New) {
     if (!info.IsConstructCall()) {
         Nan::ThrowError("Cannot call constructor as function, you need to use 'new' keyword");
         return;
     }
 
-    if (info[0]->IsExternal())
-    {
+    if (info[0]->IsExternal()) {
         v8::Local<v8::External> ext = info[0].As<v8::External>();
         void* ptr = ext->Value();
-        Layer* l =  static_cast<Layer*>(ptr);
+        Layer* l = static_cast<Layer*>(ptr);
         l->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
     }
 
-    if (info.Length() == 1)
-    {
-        if (!info[0]->IsString())
-        {
+    if (info.Length() == 1) {
+        if (!info[0]->IsString()) {
             Nan::ThrowTypeError("'name' must be a string");
             return;
         }
@@ -85,20 +77,16 @@ NAN_METHOD(Layer::New)
         l->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
-    }
-    else if (info.Length() == 2)
-    {
+    } else if (info.Length() == 2) {
         if (!info[0]->IsString() || !info[1]->IsString()) {
             Nan::ThrowTypeError("'name' and 'srs' must be a strings");
             return;
         }
-        Layer* l = new Layer(TOSTR(info[0]),TOSTR(info[1]));
+        Layer* l = new Layer(TOSTR(info[0]), TOSTR(info[1]));
         l->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
-    }
-    else
-    {
+    } else {
         Nan::ThrowTypeError("please provide Layer name and optional srs");
         return;
     }
@@ -116,8 +104,7 @@ v8::Local<v8::Value> Layer::NewInstance(mapnik::layer const& lay_ref) {
     return scope.Escape(maybe_local.ToLocalChecked());
 }
 
-NAN_GETTER(Layer::get_prop)
-{
+NAN_GETTER(Layer::get_prop) {
     Layer* l = Nan::ObjectWrap::Unwrap<Layer>(info.Holder());
     std::string a = TOSTR(property);
     if (a == "name")
@@ -127,74 +114,53 @@ NAN_GETTER(Layer::get_prop)
     else if (a == "styles") {
         std::vector<std::string> const& style_names = l->layer_->styles();
         v8::Local<v8::Array> s = Nan::New<v8::Array>(style_names.size());
-        for (unsigned i = 0; i < style_names.size(); ++i)
-        {
-            s->Set(i, Nan::New<v8::String>(style_names[i]).ToLocalChecked() );
+        for (unsigned i = 0; i < style_names.size(); ++i) {
+            s->Set(i, Nan::New<v8::String>(style_names[i]).ToLocalChecked());
         }
         info.GetReturnValue().Set(s);
-    }
-    else if (a == "datasource") {
+    } else if (a == "datasource") {
         mapnik::datasource_ptr ds = l->layer_->datasource();
-        if (ds)
-        {
-            mapnik::memory_datasource * mem_ptr = dynamic_cast<mapnik::memory_datasource*>(ds.get());
-            if (mem_ptr)
-            {
+        if (ds) {
+            mapnik::memory_datasource* mem_ptr = dynamic_cast<mapnik::memory_datasource*>(ds.get());
+            if (mem_ptr) {
                 info.GetReturnValue().Set(MemoryDatasource::NewInstance(ds));
-            }
-            else
-            {
+            } else {
                 info.GetReturnValue().Set(Datasource::NewInstance(ds));
             }
         }
         return;
-    }
-    else if (a == "minimum_scale_denominator")
-    {
+    } else if (a == "minimum_scale_denominator") {
         info.GetReturnValue().Set(Nan::New<v8::Number>(l->layer_->minimum_scale_denominator()));
-    }
-    else if (a == "maximum_scale_denominator")
-    {
+    } else if (a == "maximum_scale_denominator") {
         info.GetReturnValue().Set(Nan::New<v8::Number>(l->layer_->maximum_scale_denominator()));
-    }
-    else if (a == "queryable")
-    {
+    } else if (a == "queryable") {
         info.GetReturnValue().Set(Nan::New<v8::Boolean>(l->layer_->queryable()));
-    }
-    else if (a == "clear_label_cache")
-    {
+    } else if (a == "clear_label_cache") {
         info.GetReturnValue().Set(Nan::New<v8::Boolean>(l->layer_->clear_label_cache()));
-    }
-    else // if (a == "active")
+    } else // if (a == "active")
     {
         info.GetReturnValue().Set(Nan::New<v8::Boolean>(l->layer_->active()));
     }
 }
 
-NAN_SETTER(Layer::set_prop)
-{
+NAN_SETTER(Layer::set_prop) {
     Layer* l = Nan::ObjectWrap::Unwrap<Layer>(info.Holder());
     std::string a = TOSTR(property);
-    if (a == "name")
-    {
+    if (a == "name") {
         if (!value->IsString()) {
             Nan::ThrowTypeError("'name' must be a string");
             return;
         } else {
             l->layer_->set_name(TOSTR(value));
         }
-    }
-    else if (a == "srs")
-    {
+    } else if (a == "srs") {
         if (!value->IsString()) {
             Nan::ThrowTypeError("'srs' must be a string");
             return;
         } else {
             l->layer_->set_srs(TOSTR(value));
         }
-    }
-    else if (a == "styles")
-    {
+    } else if (a == "styles") {
         if (!value->IsArray()) {
             Nan::ThrowTypeError("Must provide an array of style names");
             return;
@@ -208,16 +174,14 @@ NAN_SETTER(Layer::set_prop)
                 i++;
             }
         }
-    }
-    else if (a == "datasource")
-    {
+    } else if (a == "datasource") {
         v8::Local<v8::Object> obj = value.As<v8::Object>();
         if (value->IsNull() || value->IsUndefined()) {
             Nan::ThrowTypeError("mapnik.Datasource, or mapnik.MemoryDatasource instance expected");
             return;
         } else {
             if (Nan::New(Datasource::constructor)->HasInstance(obj)) {
-                Datasource *d = Nan::ObjectWrap::Unwrap<Datasource>(obj);
+                Datasource* d = Nan::ObjectWrap::Unwrap<Datasource>(obj);
                 l->layer_->set_datasource(d->get());
             }
             /*else if (Nan::New(JSDatasource::constructor)->HasInstance(obj))
@@ -225,52 +189,39 @@ NAN_SETTER(Layer::set_prop)
                 JSDatasource *d = Nan::ObjectWrap::Unwrap<JSDatasource>(obj);
                 l->layer_->set_datasource(d->get());
             }*/
-            else if (Nan::New(MemoryDatasource::constructor)->HasInstance(obj))
-            {
-                MemoryDatasource *d = Nan::ObjectWrap::Unwrap<MemoryDatasource>(obj);
+            else if (Nan::New(MemoryDatasource::constructor)->HasInstance(obj)) {
+                MemoryDatasource* d = Nan::ObjectWrap::Unwrap<MemoryDatasource>(obj);
                 l->layer_->set_datasource(d->get());
-            }
-            else
-            {
+            } else {
                 Nan::ThrowTypeError("mapnik.Datasource or mapnik.MemoryDatasource instance expected");
                 return;
             }
         }
-    }
-    else if (a == "minimum_scale_denominator")
-    {
+    } else if (a == "minimum_scale_denominator") {
         if (!value->IsNumber()) {
             Nan::ThrowTypeError("Must provide a number");
             return;
         }
         l->layer_->set_minimum_scale_denominator(value->NumberValue());
-    }
-    else if (a == "maximum_scale_denominator")
-    {
+    } else if (a == "maximum_scale_denominator") {
         if (!value->IsNumber()) {
             Nan::ThrowTypeError("Must provide a number");
             return;
         }
         l->layer_->set_maximum_scale_denominator(value->NumberValue());
-    }
-    else if (a == "queryable")
-    {
+    } else if (a == "queryable") {
         if (!value->IsBoolean()) {
             Nan::ThrowTypeError("Must provide a boolean");
             return;
         }
         l->layer_->set_queryable(value->BooleanValue());
-    }
-    else if (a == "clear_label_cache")
-    {
+    } else if (a == "clear_label_cache") {
         if (!value->IsBoolean()) {
             Nan::ThrowTypeError("Must provide a boolean");
             return;
         }
         l->layer_->set_clear_label_cache(value->BooleanValue());
-    }
-    else if (a == "active")
-    {
+    } else if (a == "active") {
         if (!value->IsBoolean()) {
             Nan::ThrowTypeError("Must provide a boolean");
             return;
@@ -279,8 +230,7 @@ NAN_SETTER(Layer::set_prop)
     }
 }
 
-NAN_METHOD(Layer::describe)
-{
+NAN_METHOD(Layer::describe) {
     Layer* l = Nan::ObjectWrap::Unwrap<Layer>(info.Holder());
 
     v8::Local<v8::Object> description = Nan::New<v8::Object>();
@@ -302,22 +252,19 @@ NAN_METHOD(Layer::describe)
 
     std::vector<std::string> const& style_names = layer.styles();
     v8::Local<v8::Array> s = Nan::New<v8::Array>(style_names.size());
-    for (unsigned i = 0; i < style_names.size(); ++i)
-    {
-        s->Set(i, Nan::New<v8::String>(style_names[i]).ToLocalChecked() );
+    for (unsigned i = 0; i < style_names.size(); ++i) {
+        s->Set(i, Nan::New<v8::String>(style_names[i]).ToLocalChecked());
     }
 
-    description->Set(Nan::New("styles").ToLocalChecked(), s );
+    description->Set(Nan::New("styles").ToLocalChecked(), s);
 
     mapnik::datasource_ptr datasource = layer.datasource();
     v8::Local<v8::Object> ds = Nan::New<v8::Object>();
-    description->Set(Nan::New("datasource").ToLocalChecked(), ds );
-    if ( datasource )
-    {
+    description->Set(Nan::New("datasource").ToLocalChecked(), ds);
+    if (datasource) {
         mapnik::parameters::const_iterator it = datasource->params().begin();
         mapnik::parameters::const_iterator end = datasource->params().end();
-        for (; it != end; ++it)
-        {
+        for (; it != end; ++it) {
             node_mapnik::params_to_object(ds, it->first, it->second);
         }
     }

--- a/src/mapnik_layer.hpp
+++ b/src/mapnik_layer.hpp
@@ -8,16 +8,16 @@
 #pragma GCC diagnostic pop
 
 // stl
-#include <string>
 #include <memory>
+#include <string>
 
-
-
-namespace mapnik { class layer; }
+namespace mapnik {
+class layer;
+}
 typedef std::shared_ptr<mapnik::layer> layer_ptr;
 
-class Layer: public Nan::ObjectWrap {
-public:
+class Layer : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -33,7 +33,7 @@ public:
     Layer();
     inline layer_ptr get() { return layer_; }
 
-private:
+  private:
     ~Layer();
     layer_ptr layer_;
 };

--- a/src/mapnik_logger.cpp
+++ b/src/mapnik_logger.cpp
@@ -1,5 +1,5 @@
-#include "utils.hpp"
 #include "mapnik_logger.hpp"
+#include "utils.hpp"
 #include <mapnik/debug.hpp>
 
 Nan::Persistent<v8::FunctionTemplate> Logger::constructor;
@@ -27,10 +27,10 @@ void Logger::Initialize(v8::Local<v8::Object> target) {
     Nan::SetMethod(lcons->GetFunction().As<v8::Object>(), "setSeverity", Logger::set_severity);
 
     // Constants
-    NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),"NONE",mapnik::logger::severity_type::none);
-    NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),"ERROR",mapnik::logger::severity_type::error);
-    NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),"DEBUG",mapnik::logger::severity_type::debug);
-    NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),"WARN",mapnik::logger::severity_type::warn);
+    NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(), "NONE", mapnik::logger::severity_type::none);
+    NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(), "ERROR", mapnik::logger::severity_type::error);
+    NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(), "DEBUG", mapnik::logger::severity_type::debug);
+    NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(), "WARN", mapnik::logger::severity_type::warn);
 
     // What about booleans like:
     // ENABLE_STATS
@@ -40,12 +40,11 @@ void Logger::Initialize(v8::Local<v8::Object> target) {
     // DEBUG
 
     // Not sure if needed...
-    target->Set(Nan::New("Logger").ToLocalChecked(),lcons->GetFunction());
+    target->Set(Nan::New("Logger").ToLocalChecked(), lcons->GetFunction());
     constructor.Reset(lcons);
-
 }
 
-NAN_METHOD(Logger::New){
+NAN_METHOD(Logger::New) {
     Nan::ThrowError("a mapnik.Logger cannot be created directly - rather you should ....");
     return;
 }
@@ -57,7 +56,7 @@ NAN_METHOD(Logger::New){
  * @static
  * @returns {number} severity level
  */
-NAN_METHOD(Logger::get_severity){
+NAN_METHOD(Logger::get_severity) {
     int severity = mapnik::logger::instance().get_severity();
     info.GetReturnValue().Set(Nan::New(severity));
 }
@@ -73,7 +72,7 @@ NAN_METHOD(Logger::get_severity){
  * @param {number} severity - severity level
  * @returns {number} severity level
  */
-NAN_METHOD(Logger::set_severity){
+NAN_METHOD(Logger::set_severity) {
     if (info.Length() != 1 || !info[0]->IsNumber()) {
         Nan::ThrowTypeError("requires a severity level parameter");
         return;

--- a/src/mapnik_logger.hpp
+++ b/src/mapnik_logger.hpp
@@ -4,10 +4,12 @@
 #include <nan.h>
 
 //Forward declaration of mapnik logger
-namespace mapnik { class logger; }
+namespace mapnik {
+class logger;
+}
 
-class Logger: public Nan::ObjectWrap {
-public:
+class Logger : public Nan::ObjectWrap {
+  public:
     // V8 way of...
     static Nan::Persistent<v8::FunctionTemplate> constructor;
 
@@ -23,7 +25,7 @@ public:
     static NAN_METHOD(set_severity);
     static NAN_METHOD(evoke_error);
 
-private:
+  private:
     // Default Constructor
     Logger();
     // Deconstructor

--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -1,13 +1,13 @@
 #include "mapnik_map.hpp"
+#include "mapnik_color.hpp"      // for Color, Color::constructor
+#include "mapnik_featureset.hpp" // for Featureset
 #include "utils.hpp"
-#include "mapnik_color.hpp"             // for Color, Color::constructor
-#include "mapnik_featureset.hpp"        // for Featureset
 #if defined(GRID_RENDERER)
-#include "mapnik_grid.hpp"              // for Grid, Grid::constructor
+#include "mapnik_grid.hpp" // for Grid, Grid::constructor
 #endif
-#include "mapnik_image.hpp"             // for Image, Image::constructor
-#include "mapnik_layer.hpp"             // for Layer, Layer::constructor
-#include "mapnik_palette.hpp"           // for palette_ptr, Palette, etc
+#include "mapnik_image.hpp"   // for Image, Image::constructor
+#include "mapnik_layer.hpp"   // for Layer, Layer::constructor
+#include "mapnik_palette.hpp" // for palette_ptr, Palette, etc
 #include "mapnik_vector_tile.hpp"
 #include "object_to_container.hpp"
 
@@ -15,37 +15,37 @@
 #include "vector_tile_processor.hpp"
 
 // mapnik
-#include <mapnik/agg_renderer.hpp>      // for agg_renderer
-#include <mapnik/box2d.hpp>             // for box2d
-#include <mapnik/color.hpp>             // for color
-#include <mapnik/attribute.hpp>        // for attributes
-#include <mapnik/featureset.hpp>        // for featureset_ptr
+#include <mapnik/agg_renderer.hpp> // for agg_renderer
+#include <mapnik/attribute.hpp>    // for attributes
+#include <mapnik/box2d.hpp>        // for box2d
+#include <mapnik/color.hpp>        // for color
+#include <mapnik/featureset.hpp>   // for featureset_ptr
 #if defined(GRID_RENDERER)
-#include <mapnik/grid/grid.hpp>         // for hit_grid, grid
-#include <mapnik/grid/grid_renderer.hpp>  // for grid_renderer
+#include <mapnik/grid/grid.hpp>          // for hit_grid, grid
+#include <mapnik/grid/grid_renderer.hpp> // for grid_renderer
 #endif
-#include <mapnik/image.hpp>             // for image_rgba8
+#include <mapnik/image.hpp> // for image_rgba8
 #include <mapnik/image_any.hpp>
-#include <mapnik/image_util.hpp>        // for save_to_file, guess_type, etc
-#include <mapnik/layer.hpp>             // for layer
-#include <mapnik/load_map.hpp>          // for load_map, load_map_string
-#include <mapnik/map.hpp>               // for Map, etc
-#include <mapnik/params.hpp>            // for parameters
-#include <mapnik/save_map.hpp>          // for save_map, etc
 #include <mapnik/image_scaling.hpp>
+#include <mapnik/image_util.hpp> // for save_to_file, guess_type, etc
+#include <mapnik/layer.hpp>      // for layer
+#include <mapnik/load_map.hpp>   // for load_map, load_map_string
+#include <mapnik/map.hpp>        // for Map, etc
+#include <mapnik/params.hpp>     // for parameters
 #include <mapnik/request.hpp>
+#include <mapnik/save_map.hpp> // for save_map, etc
 #if defined(HAVE_CAIRO)
 #include <mapnik/cairo_io.hpp>
 #endif
 
 // stl
-#include <exception>                    // for exception
-#include <iosfwd>                       // for ostringstream, ostream
-#include <ostream>                      // for operator<<, basic_ostream, etc
-#include <sstream>                      // for basic_ostringstream, etc
+#include <exception> // for exception
+#include <iosfwd>    // for ostringstream, ostream
+#include <ostream>   // for operator<<, basic_ostream, etc
+#include <sstream>   // for basic_ostringstream, etc
 
 // boost
-#include <boost/optional/optional.hpp>  // for optional
+#include <boost/optional/optional.hpp> // for optional
 
 Nan::Persistent<v8::FunctionTemplate> Map::constructor;
 
@@ -114,7 +114,6 @@ void Map::Initialize(v8::Local<v8::Object> target) {
     Nan::SetPrototypeMethod(lcons, "toXML", toXML);
     Nan::SetPrototypeMethod(lcons, "resize", resize);
 
-
     Nan::SetPrototypeMethod(lcons, "render", render);
     Nan::SetPrototypeMethod(lcons, "renderSync", renderSync);
     Nan::SetPrototypeMethod(lcons, "renderFile", renderFile);
@@ -145,47 +144,43 @@ void Map::Initialize(v8::Local<v8::Object> target) {
     ATTR(lcons, "aspect_fix_mode", get_prop, set_prop);
 
     NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),
-                                "ASPECT_GROW_BBOX",mapnik::Map::GROW_BBOX)
+                                "ASPECT_GROW_BBOX", mapnik::Map::GROW_BBOX)
     NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),
-                                "ASPECT_GROW_CANVAS",mapnik::Map::GROW_CANVAS)
+                                "ASPECT_GROW_CANVAS", mapnik::Map::GROW_CANVAS)
     NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),
-                                "ASPECT_SHRINK_BBOX",mapnik::Map::SHRINK_BBOX)
+                                "ASPECT_SHRINK_BBOX", mapnik::Map::SHRINK_BBOX)
     NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),
-                                "ASPECT_SHRINK_CANVAS",mapnik::Map::SHRINK_CANVAS)
+                                "ASPECT_SHRINK_CANVAS", mapnik::Map::SHRINK_CANVAS)
     NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),
-                                "ASPECT_ADJUST_BBOX_WIDTH",mapnik::Map::ADJUST_BBOX_WIDTH)
+                                "ASPECT_ADJUST_BBOX_WIDTH", mapnik::Map::ADJUST_BBOX_WIDTH)
     NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),
-                                "ASPECT_ADJUST_BBOX_HEIGHT",mapnik::Map::ADJUST_BBOX_HEIGHT)
+                                "ASPECT_ADJUST_BBOX_HEIGHT", mapnik::Map::ADJUST_BBOX_HEIGHT)
     NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),
-                                "ASPECT_ADJUST_CANVAS_WIDTH",mapnik::Map::ADJUST_CANVAS_WIDTH)
+                                "ASPECT_ADJUST_CANVAS_WIDTH", mapnik::Map::ADJUST_CANVAS_WIDTH)
     NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),
-                                "ASPECT_ADJUST_CANVAS_HEIGHT",mapnik::Map::ADJUST_CANVAS_HEIGHT)
+                                "ASPECT_ADJUST_CANVAS_HEIGHT", mapnik::Map::ADJUST_CANVAS_HEIGHT)
     NODE_MAPNIK_DEFINE_CONSTANT(lcons->GetFunction(),
-                                "ASPECT_RESPECT",mapnik::Map::RESPECT)
-    target->Set(Nan::New("Map").ToLocalChecked(),lcons->GetFunction());
+                                "ASPECT_RESPECT", mapnik::Map::RESPECT)
+    target->Set(Nan::New("Map").ToLocalChecked(), lcons->GetFunction());
     constructor.Reset(lcons);
 }
 
-Map::Map(int width, int height) :
-    Nan::ObjectWrap(),
-    map_(std::make_shared<mapnik::Map>(width,height)),
-    in_use_(false) {}
+Map::Map(int width, int height) : Nan::ObjectWrap(),
+                                  map_(std::make_shared<mapnik::Map>(width, height)),
+                                  in_use_(false) {}
 
-Map::Map(int width, int height, std::string const& srs) :
-    Nan::ObjectWrap(),
-    map_(std::make_shared<mapnik::Map>(width,height,srs)),
-    in_use_(false) {}
+Map::Map(int width, int height, std::string const& srs) : Nan::ObjectWrap(),
+                                                          map_(std::make_shared<mapnik::Map>(width, height, srs)),
+                                                          in_use_(false) {}
 
-Map::Map() :
-    Nan::ObjectWrap(),
-    map_(),
-    in_use_(false) {}
+Map::Map() : Nan::ObjectWrap(),
+             map_(),
+             in_use_(false) {}
 
-Map::~Map() { }
+Map::~Map() {}
 
 bool Map::acquire() {
-    if (in_use_)
-    {
+    if (in_use_) {
         return false;
     }
     in_use_ = true;
@@ -196,46 +191,37 @@ void Map::release() {
     in_use_ = false;
 }
 
-NAN_METHOD(Map::New)
-{
-    if (!info.IsConstructCall())
-    {
+NAN_METHOD(Map::New) {
+    if (!info.IsConstructCall()) {
         Nan::ThrowError("Cannot call constructor as function, you need to use 'new' keyword");
         return;
     }
 
     // accept a reference or v8:External?
-    if (info[0]->IsExternal())
-    {
+    if (info[0]->IsExternal()) {
         v8::Local<v8::External> ext = info[0].As<v8::External>();
         void* ptr = ext->Value();
-        Map* m =  static_cast<Map*>(ptr);
+        Map* m = static_cast<Map*>(ptr);
         m->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
     }
 
-    if (info.Length() == 2)
-    {
-        if (!info[0]->IsNumber() || !info[1]->IsNumber())
-        {
+    if (info.Length() == 2) {
+        if (!info[0]->IsNumber() || !info[1]->IsNumber()) {
             Nan::ThrowTypeError("'width' and 'height' must be integers");
             return;
         }
-        Map* m = new Map(info[0]->IntegerValue(),info[1]->IntegerValue());
+        Map* m = new Map(info[0]->IntegerValue(), info[1]->IntegerValue());
         m->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
-    }
-    else if (info.Length() == 3)
-    {
-        if (!info[0]->IsNumber() || !info[1]->IsNumber())
-        {
+    } else if (info.Length() == 3) {
+        if (!info[0]->IsNumber() || !info[1]->IsNumber()) {
             Nan::ThrowTypeError("'width' and 'height' must be integers");
             return;
         }
-        if (!info[2]->IsString())
-        {
+        if (!info[2]->IsString()) {
             Nan::ThrowError("'srs' value must be a string");
             return;
         }
@@ -243,20 +229,17 @@ NAN_METHOD(Map::New)
         m->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
-    }
-    else
-    {
+    } else {
         Nan::ThrowError("please provide Map width and height and optional srs");
         return;
     }
     return;
 }
 
-NAN_GETTER(Map::get_prop)
-{
+NAN_GETTER(Map::get_prop) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     std::string a = TOSTR(property);
-    if(a == "extent") {
+    if (a == "extent") {
         v8::Local<v8::Array> arr = Nan::New<v8::Array>(4);
         mapnik::box2d<double> const& e = m->map_->get_current_extent();
         arr->Set(0, Nan::New<v8::Number>(e.minx()));
@@ -264,18 +247,16 @@ NAN_GETTER(Map::get_prop)
         arr->Set(2, Nan::New<v8::Number>(e.maxx()));
         arr->Set(3, Nan::New<v8::Number>(e.maxy()));
         info.GetReturnValue().Set(arr);
-    }
-    else if(a == "bufferedExtent") {
-        boost::optional<mapnik::box2d<double> > const& e = m->map_->get_buffered_extent();
+    } else if (a == "bufferedExtent") {
+        boost::optional<mapnik::box2d<double>> const& e = m->map_->get_buffered_extent();
         v8::Local<v8::Array> arr = Nan::New<v8::Array>(4);
         arr->Set(0, Nan::New<v8::Number>(e->minx()));
         arr->Set(1, Nan::New<v8::Number>(e->miny()));
         arr->Set(2, Nan::New<v8::Number>(e->maxx()));
         arr->Set(3, Nan::New<v8::Number>(e->maxy()));
         info.GetReturnValue().Set(arr);
-    }
-    else if(a == "maximumExtent") {
-        boost::optional<mapnik::box2d<double> > const& e = m->map_->maximum_extent();
+    } else if (a == "maximumExtent") {
+        boost::optional<mapnik::box2d<double>> const& e = m->map_->maximum_extent();
         if (!e)
             return;
         v8::Local<v8::Array> arr = Nan::New<v8::Array>(4);
@@ -284,16 +265,15 @@ NAN_GETTER(Map::get_prop)
         arr->Set(2, Nan::New<v8::Number>(e->maxx()));
         arr->Set(3, Nan::New<v8::Number>(e->maxy()));
         info.GetReturnValue().Set(arr);
-    }
-    else if(a == "aspect_fix_mode")
+    } else if (a == "aspect_fix_mode")
         info.GetReturnValue().Set(Nan::New<v8::Integer>(m->map_->get_aspect_fix_mode()));
-    else if(a == "width")
+    else if (a == "width")
         info.GetReturnValue().Set(Nan::New<v8::Integer>(m->map_->width()));
-    else if(a == "height")
+    else if (a == "height")
         info.GetReturnValue().Set(Nan::New<v8::Integer>(m->map_->height()));
     else if (a == "srs")
         info.GetReturnValue().Set(Nan::New<v8::String>(m->map_->srs()).ToLocalChecked());
-    else if(a == "bufferSize")
+    else if (a == "bufferSize")
         info.GetReturnValue().Set(Nan::New<v8::Integer>(m->map_->buffer_size()));
     else if (a == "background") {
         boost::optional<mapnik::color> c = m->map_->background();
@@ -301,26 +281,23 @@ NAN_GETTER(Map::get_prop)
             info.GetReturnValue().Set(Color::NewInstance(*c));
         else
             return;
-    }
-    else //if (a == "parameters")
+    } else //if (a == "parameters")
     {
         v8::Local<v8::Object> ds = Nan::New<v8::Object>();
         mapnik::parameters const& params = m->map_->get_extra_parameters();
         mapnik::parameters::const_iterator it = params.begin();
         mapnik::parameters::const_iterator end = params.end();
-        for (; it != end; ++it)
-        {
+        for (; it != end; ++it) {
             node_mapnik::params_to_object(ds, it->first, it->second);
         }
         info.GetReturnValue().Set(ds);
     }
 }
 
-NAN_SETTER(Map::set_prop)
-{
+NAN_SETTER(Map::set_prop) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     std::string a = TOSTR(property);
-    if(a == "extent" || a == "maximumExtent") {
+    if (a == "extent" || a == "maximumExtent") {
         if (!value->IsArray()) {
             Nan::ThrowError("Must provide an array of: [minx,miny,maxx,maxy]");
             return;
@@ -334,16 +311,14 @@ NAN_SETTER(Map::set_prop)
                 double miny = arr->Get(1)->NumberValue();
                 double maxx = arr->Get(2)->NumberValue();
                 double maxy = arr->Get(3)->NumberValue();
-                mapnik::box2d<double> box(minx,miny,maxx,maxy);
-                if(a == "extent")
+                mapnik::box2d<double> box(minx, miny, maxx, maxy);
+                if (a == "extent")
                     m->map_->zoom_to_box(box);
                 else
                     m->map_->set_maximum_extent(box);
             }
         }
-    }
-    else if (a == "aspect_fix_mode")
-    {
+    } else if (a == "aspect_fix_mode") {
         if (!value->IsNumber()) {
             Nan::ThrowError("'aspect_fix_mode' must be a constant (number)");
             return;
@@ -356,41 +331,35 @@ NAN_SETTER(Map::set_prop)
                 return;
             }
         }
-    }
-    else if (a == "srs")
-    {
+    } else if (a == "srs") {
         if (!value->IsString()) {
             Nan::ThrowError("'srs' must be a string");
             return;
         } else {
             m->map_->set_srs(TOSTR(value));
         }
-    }
-    else if (a == "bufferSize") {
+    } else if (a == "bufferSize") {
         if (!value->IsNumber()) {
             Nan::ThrowTypeError("Must provide an integer bufferSize");
             return;
         } else {
             m->map_->set_buffer_size(value->IntegerValue());
         }
-    }
-    else if (a == "width") {
+    } else if (a == "width") {
         if (!value->IsNumber()) {
             Nan::ThrowTypeError("Must provide an integer width");
             return;
         } else {
             m->map_->set_width(value->IntegerValue());
         }
-    }
-    else if (a == "height") {
+    } else if (a == "height") {
         if (!value->IsNumber()) {
             Nan::ThrowTypeError("Must provide an integer height");
             return;
         } else {
             m->map_->set_height(value->IntegerValue());
         }
-    }
-    else if (a == "background") {
+    } else if (a == "background") {
         if (!value->IsObject()) {
             Nan::ThrowTypeError("mapnik.Color expected");
             return;
@@ -401,10 +370,9 @@ NAN_SETTER(Map::set_prop)
             Nan::ThrowTypeError("mapnik.Color expected");
             return;
         }
-        Color *c = Nan::ObjectWrap::Unwrap<Color>(obj);
+        Color* c = Nan::ObjectWrap::Unwrap<Color>(obj);
         m->map_->set_background(*c->get());
-    }
-    else if (a == "parameters") {
+    } else if (a == "parameters") {
         if (!value->IsObject()) {
             Nan::ThrowTypeError("object expected for map.parameters");
             return;
@@ -446,49 +414,40 @@ NAN_SETTER(Map::set_prop)
  * @instance
  *
  */
-NAN_METHOD(Map::loadFonts)
-{
+NAN_METHOD(Map::loadFonts) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     info.GetReturnValue().Set(Nan::New<v8::Boolean>(m->map_->load_fonts()));
 }
 
-NAN_METHOD(Map::memoryFonts)
-{
+NAN_METHOD(Map::memoryFonts) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     auto const& font_cache = m->map_->get_font_memory_cache();
     v8::Local<v8::Array> a = Nan::New<v8::Array>(font_cache.size());
     unsigned i = 0;
-    for (auto const& kv : font_cache)
-    {
+    for (auto const& kv : font_cache) {
         a->Set(i++, Nan::New(kv.first).ToLocalChecked());
     }
     info.GetReturnValue().Set(a);
 }
 
-NAN_METHOD(Map::registerFonts)
-{
+NAN_METHOD(Map::registerFonts) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
-    if (info.Length() == 0 || !info[0]->IsString())
-    {
+    if (info.Length() == 0 || !info[0]->IsString()) {
         Nan::ThrowTypeError("first argument must be a path to a directory of fonts");
         return;
     }
 
     bool recurse = false;
 
-    if (info.Length() >= 2)
-    {
-        if (!info[1]->IsObject())
-        {
+    if (info.Length() >= 2) {
+        if (!info[1]->IsObject()) {
             Nan::ThrowTypeError("second argument is optional, but if provided must be an object, eg. { recurse: true }");
             return;
         }
         v8::Local<v8::Object> options = info[1].As<v8::Object>();
-        if (options->Has(Nan::New("recurse").ToLocalChecked()))
-        {
+        if (options->Has(Nan::New("recurse").ToLocalChecked())) {
             v8::Local<v8::Value> recurse_opt = options->Get(Nan::New("recurse").ToLocalChecked());
-            if (!recurse_opt->IsBoolean())
-            {
+            if (!recurse_opt->IsBoolean()) {
                 Nan::ThrowTypeError("'recurse' must be a Boolean");
                 return;
             }
@@ -496,7 +455,7 @@ NAN_METHOD(Map::registerFonts)
         }
     }
     std::string path = TOSTR(info[0]);
-    info.GetReturnValue().Set(Nan::New(m->map_->register_fonts(path,recurse)));
+    info.GetReturnValue().Set(Nan::New(m->map_->register_fonts(path, recurse)));
 }
 
 /**
@@ -506,14 +465,12 @@ NAN_METHOD(Map::registerFonts)
  * @name font
  * @returns {Array<string>} fonts
  */
-NAN_METHOD(Map::fonts)
-{
+NAN_METHOD(Map::fonts) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     auto const& mapping = m->map_->get_font_file_mapping();
     v8::Local<v8::Array> a = Nan::New<v8::Array>(mapping.size());
     unsigned i = 0;
-    for (auto const& kv : mapping)
-    {
+    for (auto const& kv : mapping) {
         a->Set(i++, Nan::New<v8::String>(kv.first).ToLocalChecked());
     }
     info.GetReturnValue().Set(a);
@@ -527,13 +484,11 @@ NAN_METHOD(Map::fonts)
  * @name fontFiles
  * @returns {Object} fonts
  */
-NAN_METHOD(Map::fontFiles)
-{
+NAN_METHOD(Map::fontFiles) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     auto const& mapping = m->map_->get_font_file_mapping();
     v8::Local<v8::Object> obj = Nan::New<v8::Object>();
-    for (auto const& kv : mapping)
-    {
+    for (auto const& kv : mapping) {
         obj->Set(Nan::New<v8::String>(kv.first).ToLocalChecked(), Nan::New<v8::String>(kv.second.second).ToLocalChecked());
     }
     info.GetReturnValue().Set(obj);
@@ -546,12 +501,10 @@ NAN_METHOD(Map::fontFiles)
  * @name fontDirectory
  * @returns {string|undefined} fonts
  */
-NAN_METHOD(Map::fontDirectory)
-{
+NAN_METHOD(Map::fontDirectory) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     boost::optional<std::string> const& fdir = m->map_->font_directory();
-    if (fdir)
-    {
+    if (fdir) {
         info.GetReturnValue().Set(Nan::New<v8::String>(*fdir).ToLocalChecked());
     }
     return;
@@ -565,8 +518,7 @@ NAN_METHOD(Map::fontDirectory)
  * @name scale
  * @returns {number} scale
  */
-NAN_METHOD(Map::scale)
-{
+NAN_METHOD(Map::scale) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     info.GetReturnValue().Set(Nan::New<v8::Number>(m->map_->scale()));
 }
@@ -579,16 +531,15 @@ NAN_METHOD(Map::scale)
  * @name scaleDenominator
  * @returns {number} scale denominator
  */
-NAN_METHOD(Map::scaleDenominator)
-{
+NAN_METHOD(Map::scaleDenominator) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     info.GetReturnValue().Set(Nan::New<v8::Number>(m->map_->scale_denominator()));
 }
 
 typedef struct {
     uv_work_t request;
-    Map *m;
-    std::map<std::string,mapnik::featureset_ptr> featuresets;
+    Map* m;
+    std::map<std::string, mapnik::featureset_ptr> featuresets;
     int layer_idx;
     bool geo_coords;
     double x;
@@ -628,9 +579,8 @@ typedef struct {
  * });
  *
  */
-NAN_METHOD(Map::queryMapPoint)
-{
-    abstractQueryPoint(info,false);
+NAN_METHOD(Map::queryMapPoint) {
+    abstractQueryPoint(info, false);
     return;
 }
 
@@ -664,29 +614,23 @@ NAN_METHOD(Map::queryMapPoint)
  * });
  *
  */
-NAN_METHOD(Map::queryPoint)
-{
-    abstractQueryPoint(info,true);
+NAN_METHOD(Map::queryPoint) {
+    abstractQueryPoint(info, true);
     return;
 }
 
-v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, bool geo_coords)
-{
+v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, bool geo_coords) {
     Nan::HandleScope scope;
-    if (info.Length() < 3)
-    {
+    if (info.Length() < 3) {
         Nan::ThrowError("requires at least three arguments, a x,y query and a callback");
         return Nan::Undefined();
     }
 
-    double x,y;
-    if (!info[0]->IsNumber() || !info[1]->IsNumber())
-    {
+    double x, y;
+    if (!info[0]->IsNumber() || !info[1]->IsNumber()) {
         Nan::ThrowTypeError("x,y arguments must be numbers");
         return Nan::Undefined();
-    }
-    else
-    {
+    } else {
         x = info[0]->NumberValue();
         y = info[1]->NumberValue();
     }
@@ -696,8 +640,7 @@ v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, boo
     v8::Local<v8::Object> options = Nan::New<v8::Object>();
     int layer_idx = -1;
 
-    if (info.Length() > 3)
-    {
+    if (info.Length() > 3) {
         // options object
         if (!info[2]->IsObject()) {
             Nan::ThrowTypeError("optional third argument must be an options object");
@@ -706,11 +649,10 @@ v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, boo
 
         options = info[2]->ToObject();
 
-        if (options->Has(Nan::New("layer").ToLocalChecked()))
-        {
+        if (options->Has(Nan::New("layer").ToLocalChecked())) {
             std::vector<mapnik::layer> const& layers = m->map_->layers();
             v8::Local<v8::Value> layer_id = options->Get(Nan::New("layer").ToLocalChecked());
-            if (! (layer_id->IsString() || layer_id->IsNumber()) ) {
+            if (!(layer_id->IsString() || layer_id->IsNumber())) {
                 Nan::ThrowTypeError("'layer' option required for map query and must be either a layer name(string) or layer index (integer)");
                 return Nan::Undefined();
             }
@@ -719,26 +661,21 @@ v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, boo
                 bool found = false;
                 unsigned int idx(0);
                 std::string layer_name = TOSTR(layer_id);
-                for (mapnik::layer const& lyr : layers)
-                {
-                    if (lyr.name() == layer_name)
-                    {
+                for (mapnik::layer const& lyr : layers) {
+                    if (lyr.name() == layer_name) {
                         found = true;
                         layer_idx = idx;
                         break;
                     }
                     ++idx;
                 }
-                if (!found)
-                {
+                if (!found) {
                     std::ostringstream s;
                     s << "Layer name '" << layer_name << "' not found";
                     Nan::ThrowTypeError(s.str().c_str());
                     return Nan::Undefined();
                 }
-            }
-            else if (layer_id->IsNumber())
-            {
+            } else if (layer_id->IsNumber()) {
                 layer_idx = layer_id->IntegerValue();
                 std::size_t layer_num = layers.size();
 
@@ -746,12 +683,9 @@ v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, boo
                     std::ostringstream s;
                     s << "Zero-based layer index '" << layer_idx << "' not valid"
                       << " must be a positive integer, ";
-                    if (layer_num > 0)
-                    {
+                    if (layer_num > 0) {
                         s << "only '" << layer_num << "' layers exist in map";
-                    }
-                    else
-                    {
+                    } else {
                         s << "no layers found in map";
                     }
                     Nan::ThrowTypeError(s.str().c_str());
@@ -759,12 +693,9 @@ v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, boo
                 } else if (layer_idx >= static_cast<int>(layer_num)) {
                     std::ostringstream s;
                     s << "Zero-based layer index '" << layer_idx << "' not valid, ";
-                    if (layer_num > 0)
-                    {
+                    if (layer_num > 0) {
                         s << "only '" << layer_num << "' layers exist in map";
-                    }
-                    else
-                    {
+                    } else {
                         s << "no layers found in map";
                     }
                     Nan::ThrowTypeError(s.str().c_str());
@@ -781,7 +712,7 @@ v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, boo
         return Nan::Undefined();
     }
 
-    query_map_baton_t *closure = new query_map_baton_t();
+    query_map_baton_t* closure = new query_map_baton_t();
     closure->request.data = closure;
     closure->m = m;
     closure->x = x;
@@ -795,80 +726,63 @@ v8::Local<v8::Value> Map::abstractQueryPoint(Nan::NAN_METHOD_ARGS_TYPE info, boo
     return Nan::Undefined();
 }
 
-void Map::EIO_QueryMap(uv_work_t* req)
-{
-    query_map_baton_t *closure = static_cast<query_map_baton_t *>(req->data);
+void Map::EIO_QueryMap(uv_work_t* req) {
+    query_map_baton_t* closure = static_cast<query_map_baton_t*>(req->data);
 
-    try
-    {
+    try {
         std::vector<mapnik::layer> const& layers = closure->m->map_->layers();
-        if (closure->layer_idx >= 0)
-        {
+        if (closure->layer_idx >= 0) {
             mapnik::featureset_ptr fs;
-            if (closure->geo_coords)
-            {
+            if (closure->geo_coords) {
                 fs = closure->m->map_->query_point(closure->layer_idx,
                                                    closure->x,
                                                    closure->y);
-            }
-            else
-            {
+            } else {
                 fs = closure->m->map_->query_map_point(closure->layer_idx,
                                                        closure->x,
                                                        closure->y);
             }
             mapnik::layer const& lyr = layers[closure->layer_idx];
-            closure->featuresets.insert(std::make_pair(lyr.name(),fs));
-        }
-        else
-        {
+            closure->featuresets.insert(std::make_pair(lyr.name(), fs));
+        } else {
             // query all layers
             unsigned idx = 0;
-            for (mapnik::layer const& lyr : layers)
-            {
+            for (mapnik::layer const& lyr : layers) {
                 mapnik::featureset_ptr fs;
-                if (closure->geo_coords)
-                {
+                if (closure->geo_coords) {
                     fs = closure->m->map_->query_point(idx,
                                                        closure->x,
                                                        closure->y);
-                }
-                else
-                {
+                } else {
                     fs = closure->m->map_->query_map_point(idx,
                                                            closure->x,
                                                            closure->y);
                 }
-                closure->featuresets.insert(std::make_pair(lyr.name(),fs));
+                closure->featuresets.insert(std::make_pair(lyr.name(), fs));
                 ++idx;
             }
         }
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         closure->error = true;
         closure->error_name = ex.what();
     }
 }
 
-void Map::EIO_AfterQueryMap(uv_work_t* req)
-{
+void Map::EIO_AfterQueryMap(uv_work_t* req) {
     Nan::HandleScope scope;
-    query_map_baton_t *closure = static_cast<query_map_baton_t *>(req->data);
+    query_map_baton_t* closure = static_cast<query_map_baton_t*>(req->data);
     if (closure->error) {
-        v8::Local<v8::Value> argv[1] = { Nan::Error(closure->error_name.c_str()) };
+        v8::Local<v8::Value> argv[1] = {Nan::Error(closure->error_name.c_str())};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     } else {
         std::size_t num_result = closure->featuresets.size();
-        if (num_result >= 1)
-        {
+        if (num_result >= 1) {
             v8::Local<v8::Array> a = Nan::New<v8::Array>(num_result);
-            typedef std::map<std::string,mapnik::featureset_ptr> fs_itr;
+            typedef std::map<std::string, mapnik::featureset_ptr> fs_itr;
             fs_itr::const_iterator it = closure->featuresets.begin();
             fs_itr::const_iterator end = closure->featuresets.end();
             unsigned idx = 0;
-            for (; it != end; ++it)
-            {
+            for (; it != end; ++it) {
                 v8::Local<v8::Object> obj = Nan::New<v8::Object>();
                 obj->Set(Nan::New("layer").ToLocalChecked(), Nan::New<v8::String>(it->first).ToLocalChecked());
                 obj->Set(Nan::New("featureset").ToLocalChecked(), Featureset::NewInstance(it->second));
@@ -876,12 +790,10 @@ void Map::EIO_AfterQueryMap(uv_work_t* req)
                 ++idx;
             }
             closure->featuresets.clear();
-            v8::Local<v8::Value> argv[2] = { Nan::Null(), a };
+            v8::Local<v8::Value> argv[2] = {Nan::Null(), a};
             Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
-        }
-        else
-        {
-            v8::Local<v8::Value> argv[2] = { Nan::Null(), Nan::Undefined() };
+        } else {
+            v8::Local<v8::Value> argv[2] = {Nan::Null(), Nan::Undefined()};
             Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
         }
     }
@@ -899,13 +811,11 @@ void Map::EIO_AfterQueryMap(uv_work_t* req)
  * @name layers
  * @returns {Array<mapnik.Layer>} layers
  */
-NAN_METHOD(Map::layers)
-{
+NAN_METHOD(Map::layers) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     std::vector<mapnik::layer> const& layers = m->map_->layers();
     v8::Local<v8::Array> a = Nan::New<v8::Array>(layers.size());
-    for (unsigned i = 0; i < layers.size(); ++i )
-    {
+    for (unsigned i = 0; i < layers.size(); ++i) {
         a->Set(i, Layer::NewInstance(layers[i]));
     }
     info.GetReturnValue().Set(a);
@@ -930,7 +840,7 @@ NAN_METHOD(Map::add_layer) {
         Nan::ThrowTypeError("mapnik.Layer expected");
         return;
     }
-    Layer *l = Nan::ObjectWrap::Unwrap<Layer>(obj);
+    Layer* l = Nan::ObjectWrap::Unwrap<Layer>(obj);
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     m->map_->add_layer(*l->get());
     return;
@@ -946,8 +856,7 @@ NAN_METHOD(Map::add_layer) {
  * @returns {mapnik.Layer} the layer
  * @throws {Error} if index is incorrect or layer is not found
  */
-NAN_METHOD(Map::get_layer)
-{
+NAN_METHOD(Map::get_layer) {
     if (info.Length() != 1) {
         Nan::ThrowError("Please provide layer name or index");
         return;
@@ -957,44 +866,34 @@ NAN_METHOD(Map::get_layer)
     std::vector<mapnik::layer> const& layers = m->map_->layers();
 
     v8::Local<v8::Value> layer = info[0];
-    if (layer->IsNumber())
-    {
+    if (layer->IsNumber()) {
         unsigned int index = info[0]->IntegerValue();
 
-        if (index < layers.size())
-        {
+        if (index < layers.size()) {
             info.GetReturnValue().Set(Layer::NewInstance(layers[index]));
             return;
-        }
-        else
-        {
+        } else {
             Nan::ThrowTypeError("invalid layer index");
             return;
         }
-    }
-    else if (layer->IsString())
-    {
+    } else if (layer->IsString()) {
         bool found = false;
         unsigned int idx(0);
         std::string layer_name = TOSTR(layer);
-        for ( mapnik::layer const& lyr : layers)
-        {
-            if (lyr.name() == layer_name)
-            {
+        for (mapnik::layer const& lyr : layers) {
+            if (lyr.name() == layer_name) {
                 found = true;
                 info.GetReturnValue().Set(Layer::NewInstance(layers[idx]));
                 return;
             }
             ++idx;
         }
-        if (!found)
-        {
+        if (!found) {
             std::ostringstream s;
             s << "Layer name '" << layer_name << "' not found";
             Nan::ThrowTypeError(s.str().c_str());
             return;
         }
-
     }
     Nan::ThrowTypeError("first argument must be either a layer name(string) or layer index (integer)");
     return;
@@ -1007,8 +906,7 @@ NAN_METHOD(Map::get_layer)
  * @instance
  * @name clear
  */
-NAN_METHOD(Map::clear)
-{
+NAN_METHOD(Map::clear) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     m->map_->remove_all();
     return;
@@ -1023,8 +921,7 @@ NAN_METHOD(Map::clear)
  * @param {number} width
  * @param {number} height
  */
-NAN_METHOD(Map::resize)
-{
+NAN_METHOD(Map::resize) {
     if (info.Length() != 2) {
         Nan::ThrowError("Please provide width and height");
         return;
@@ -1036,14 +933,13 @@ NAN_METHOD(Map::resize)
     }
 
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
-    m->map_->resize(info[0]->IntegerValue(),info[1]->IntegerValue());
+    m->map_->resize(info[0]->IntegerValue(), info[1]->IntegerValue());
     return;
 }
 
-
 typedef struct {
     uv_work_t request;
-    Map *m;
+    Map* m;
     std::string stylesheet;
     std::string base_path;
     bool strict;
@@ -1051,7 +947,6 @@ typedef struct {
     std::string error_name;
     Nan::Persistent<v8::Function> cb;
 } load_xml_baton_t;
-
 
 /**
  * Load styles, layers, and other information for this map from a Mapnik
@@ -1064,8 +959,7 @@ typedef struct {
  * @param {Object} [options={}]
  * @param {Function} callback
  */
-NAN_METHOD(Map::load)
-{
+NAN_METHOD(Map::load) {
     if (info.Length() < 2) {
         Nan::ThrowError("please provide a stylesheet path, options, and callback");
         return;
@@ -1079,7 +973,7 @@ NAN_METHOD(Map::load)
     }
 
     // ensure callback is a function
-    v8::Local<v8::Value> callback = info[info.Length()-1];
+    v8::Local<v8::Value> callback = info[info.Length() - 1];
     if (!callback->IsFunction()) {
         Nan::ThrowTypeError("last argument must be a callback function");
         return;
@@ -1095,8 +989,7 @@ NAN_METHOD(Map::load)
 
     bool strict = false;
     v8::Local<v8::String> param = Nan::New("strict").ToLocalChecked();
-    if (options->Has(param))
-    {
+    if (options->Has(param)) {
         v8::Local<v8::Value> param_val = options->Get(param);
         if (!param_val->IsBoolean()) {
             Nan::ThrowTypeError("'strict' must be a Boolean");
@@ -1107,12 +1000,11 @@ NAN_METHOD(Map::load)
 
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
 
-    load_xml_baton_t *closure = new load_xml_baton_t();
+    load_xml_baton_t* closure = new load_xml_baton_t();
     closure->request.data = closure;
 
     param = Nan::New("base").ToLocalChecked();
-    if (options->Has(param))
-    {
+    if (options->Has(param)) {
         v8::Local<v8::Value> param_val = options->Get(param);
         if (!param_val->IsString()) {
             Nan::ThrowTypeError("'base' must be a string representing a filesystem path");
@@ -1131,30 +1023,25 @@ NAN_METHOD(Map::load)
     return;
 }
 
-void Map::EIO_Load(uv_work_t* req)
-{
-    load_xml_baton_t *closure = static_cast<load_xml_baton_t *>(req->data);
+void Map::EIO_Load(uv_work_t* req) {
+    load_xml_baton_t* closure = static_cast<load_xml_baton_t*>(req->data);
 
-    try
-    {
-        mapnik::load_map(*closure->m->map_,closure->stylesheet,closure->strict,closure->base_path);
-    }
-    catch (std::exception const& ex)
-    {
+    try {
+        mapnik::load_map(*closure->m->map_, closure->stylesheet, closure->strict, closure->base_path);
+    } catch (std::exception const& ex) {
         closure->error = true;
         closure->error_name = ex.what();
     }
 }
 
-void Map::EIO_AfterLoad(uv_work_t* req)
-{
+void Map::EIO_AfterLoad(uv_work_t* req) {
     Nan::HandleScope scope;
-    load_xml_baton_t *closure = static_cast<load_xml_baton_t *>(req->data);
+    load_xml_baton_t* closure = static_cast<load_xml_baton_t*>(req->data);
     if (closure->error) {
-        v8::Local<v8::Value> argv[1] = { Nan::Error(closure->error_name.c_str()) };
+        v8::Local<v8::Value> argv[1] = {Nan::Error(closure->error_name.c_str())};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     } else {
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->m->handle() };
+        v8::Local<v8::Value> argv[2] = {Nan::Null(), closure->m->handle()};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
@@ -1162,7 +1049,6 @@ void Map::EIO_AfterLoad(uv_work_t* req)
     closure->cb.Reset();
     delete closure;
 }
-
 
 /**
  * Load styles, layers, and other information for this map from a Mapnik
@@ -1176,8 +1062,7 @@ void Map::EIO_AfterLoad(uv_work_t* req)
  * @example
  * map.loadSync('./style.xml');
  */
-NAN_METHOD(Map::loadSync)
-{
+NAN_METHOD(Map::loadSync) {
     if (!info[0]->IsString()) {
         Nan::ThrowTypeError("first argument must be a path to a mapnik stylesheet");
         return;
@@ -1188,17 +1073,13 @@ NAN_METHOD(Map::loadSync)
     bool strict = false;
     std::string base_path;
 
-    if (info.Length() > 2)
-    {
+    if (info.Length() > 2) {
 
         Nan::ThrowError("only accepts two arguments: a path to a mapnik stylesheet and an optional options object");
         return;
-    }
-    else if (info.Length() == 2)
-    {
+    } else if (info.Length() == 2) {
         // ensure options object
-        if (!info[1]->IsObject())
-        {
+        if (!info[1]->IsObject()) {
             Nan::ThrowTypeError("options must be an object, eg {strict: true}");
             return;
         }
@@ -1206,11 +1087,9 @@ NAN_METHOD(Map::loadSync)
         v8::Local<v8::Object> options = info[1].As<v8::Object>();
 
         v8::Local<v8::String> param = Nan::New("strict").ToLocalChecked();
-        if (options->Has(param))
-        {
+        if (options->Has(param)) {
             v8::Local<v8::Value> param_val = options->Get(param);
-            if (!param_val->IsBoolean())
-            {
+            if (!param_val->IsBoolean()) {
                 Nan::ThrowTypeError("'strict' must be a Boolean");
                 return;
             }
@@ -1218,11 +1097,9 @@ NAN_METHOD(Map::loadSync)
         }
 
         param = Nan::New("base").ToLocalChecked();
-        if (options->Has(param))
-        {
+        if (options->Has(param)) {
             v8::Local<v8::Value> param_val = options->Get(param);
-            if (!param_val->IsString())
-            {
+            if (!param_val->IsString()) {
                 Nan::ThrowTypeError("'base' must be a string representing a filesystem path");
                 return;
             }
@@ -1230,12 +1107,9 @@ NAN_METHOD(Map::loadSync)
         }
     }
 
-    try
-    {
-        mapnik::load_map(*m->map_,stylesheet,strict,base_path);
-    }
-    catch (std::exception const& ex)
-    {
+    try {
+        mapnik::load_map(*m->map_, stylesheet, strict, base_path);
+    } catch (std::exception const& ex) {
         Nan::ThrowError(ex.what());
         return;
     }
@@ -1255,8 +1129,7 @@ NAN_METHOD(Map::loadSync)
  * var fs = require('fs');
  * map.fromStringSync(fs.readFileSync('./style.xml', 'utf8'));
  */
-NAN_METHOD(Map::fromStringSync)
-{
+NAN_METHOD(Map::fromStringSync) {
     if (info.Length() < 1) {
         Nan::ThrowError("Accepts 2 arguments: stylesheet string and an optional options");
         return;
@@ -1266,7 +1139,6 @@ NAN_METHOD(Map::fromStringSync)
         Nan::ThrowTypeError("first argument must be a mapnik stylesheet string");
         return;
     }
-
 
     // defaults
     bool strict = false;
@@ -1282,8 +1154,7 @@ NAN_METHOD(Map::fromStringSync)
         v8::Local<v8::Object> options = info[1].As<v8::Object>();
 
         v8::Local<v8::String> param = Nan::New("strict").ToLocalChecked();
-        if (options->Has(param))
-        {
+        if (options->Has(param)) {
             v8::Local<v8::Value> param_val = options->Get(param);
             if (!param_val->IsBoolean()) {
                 Nan::ThrowTypeError("'strict' must be a Boolean");
@@ -1293,8 +1164,7 @@ NAN_METHOD(Map::fromStringSync)
         }
 
         param = Nan::New("base").ToLocalChecked();
-        if (options->Has(param))
-        {
+        if (options->Has(param)) {
             v8::Local<v8::Value> param_val = options->Get(param);
             if (!param_val->IsString()) {
                 Nan::ThrowTypeError("'base' must be a string representing a filesystem path");
@@ -1308,12 +1178,9 @@ NAN_METHOD(Map::fromStringSync)
 
     std::string stylesheet = TOSTR(info[0]);
 
-    try
-    {
-        mapnik::load_map_string(*m->map_,stylesheet,strict,base_path);
-    }
-    catch (std::exception const& ex)
-    {
+    try {
+        mapnik::load_map_string(*m->map_, stylesheet, strict, base_path);
+    } catch (std::exception const& ex) {
         Nan::ThrowError(ex.what());
         return;
     }
@@ -1336,33 +1203,28 @@ NAN_METHOD(Map::fromStringSync)
  *   // details loaded
  * });
  */
-NAN_METHOD(Map::fromString)
-{
-    if (info.Length() < 2)
-    {
+NAN_METHOD(Map::fromString) {
+    if (info.Length() < 2) {
         Nan::ThrowError("please provide a stylesheet string, options, and callback");
         return;
     }
 
     // ensure stylesheet path is a string
     v8::Local<v8::Value> stylesheet = info[0];
-    if (!stylesheet->IsString())
-    {
+    if (!stylesheet->IsString()) {
         Nan::ThrowTypeError("first argument must be a path to a mapnik stylesheet string");
         return;
     }
 
     // ensure callback is a function
-    v8::Local<v8::Value> callback = info[info.Length()-1];
-    if (!info[info.Length()-1]->IsFunction())
-    {
+    v8::Local<v8::Value> callback = info[info.Length() - 1];
+    if (!info[info.Length() - 1]->IsFunction()) {
         Nan::ThrowTypeError("last argument must be a callback function");
         return;
     }
 
     // ensure options object
-    if (!info[1]->IsObject())
-    {
+    if (!info[1]->IsObject()) {
         Nan::ThrowTypeError("options must be an object, eg {strict: true, base: \".\"'}");
         return;
     }
@@ -1371,11 +1233,9 @@ NAN_METHOD(Map::fromString)
 
     bool strict = false;
     v8::Local<v8::String> param = Nan::New("strict").ToLocalChecked();
-    if (options->Has(param))
-    {
+    if (options->Has(param)) {
         v8::Local<v8::Value> param_val = options->Get(param);
-        if (!param_val->IsBoolean())
-        {
+        if (!param_val->IsBoolean()) {
             Nan::ThrowTypeError("'strict' must be a Boolean");
             return;
         }
@@ -1384,15 +1244,13 @@ NAN_METHOD(Map::fromString)
 
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
 
-    load_xml_baton_t *closure = new load_xml_baton_t();
+    load_xml_baton_t* closure = new load_xml_baton_t();
     closure->request.data = closure;
 
     param = Nan::New("base").ToLocalChecked();
-    if (options->Has(param))
-    {
+    if (options->Has(param)) {
         v8::Local<v8::Value> param_val = options->Get(param);
-        if (!param_val->IsString())
-        {
+        if (!param_val->IsString()) {
             Nan::ThrowTypeError("'base' must be a string representing a filesystem path");
             return;
         }
@@ -1409,30 +1267,25 @@ NAN_METHOD(Map::fromString)
     return;
 }
 
-void Map::EIO_FromString(uv_work_t* req)
-{
-    load_xml_baton_t *closure = static_cast<load_xml_baton_t *>(req->data);
+void Map::EIO_FromString(uv_work_t* req) {
+    load_xml_baton_t* closure = static_cast<load_xml_baton_t*>(req->data);
 
-    try
-    {
-        mapnik::load_map_string(*closure->m->map_,closure->stylesheet,closure->strict,closure->base_path);
-    }
-    catch (std::exception const& ex)
-    {
+    try {
+        mapnik::load_map_string(*closure->m->map_, closure->stylesheet, closure->strict, closure->base_path);
+    } catch (std::exception const& ex) {
         closure->error = true;
         closure->error_name = ex.what();
     }
 }
 
-void Map::EIO_AfterFromString(uv_work_t* req)
-{
+void Map::EIO_AfterFromString(uv_work_t* req) {
     Nan::HandleScope scope;
-    load_xml_baton_t *closure = static_cast<load_xml_baton_t *>(req->data);
+    load_xml_baton_t* closure = static_cast<load_xml_baton_t*>(req->data);
     if (closure->error) {
-        v8::Local<v8::Value> argv[1] = { Nan::Error(closure->error_name.c_str()) };
+        v8::Local<v8::Value> argv[1] = {Nan::Error(closure->error_name.c_str())};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     } else {
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->m->handle() };
+        v8::Local<v8::Value> argv[2] = {Nan::Null(), closure->m->handle()};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
@@ -1450,15 +1303,16 @@ void Map::EIO_AfterFromString(uv_work_t* req)
  * @memberof Map
  * @returns {mapnik.Map} clone
  */
-NAN_METHOD(Map::clone)
-{
+NAN_METHOD(Map::clone) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     Map* m2 = new Map();
     m2->map_ = std::make_shared<mapnik::Map>(*m->map_);
     v8::Local<v8::Value> ext = Nan::New<v8::External>(m2);
     Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
-    if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Map instance");
-    else info.GetReturnValue().Set(maybe_local.ToLocalChecked());
+    if (maybe_local.IsEmpty())
+        Nan::ThrowError("Could not create new Map instance");
+    else
+        info.GetReturnValue().Set(maybe_local.ToLocalChecked());
 }
 
 /**
@@ -1472,10 +1326,8 @@ NAN_METHOD(Map::clone)
  * map.save("path/to/map.xml");
  */
 
-NAN_METHOD(Map::save)
-{
-    if (info.Length() != 1 || !info[0]->IsString())
-    {
+NAN_METHOD(Map::save) {
+    if (info.Length() != 1 || !info[0]->IsString()) {
         Nan::ThrowTypeError("first argument must be a path to map.xml to save");
         return;
     }
@@ -1483,7 +1335,7 @@ NAN_METHOD(Map::save)
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     std::string filename = TOSTR(info[0]);
     bool explicit_defaults = false;
-    mapnik::save_map(*m->map_,filename,explicit_defaults);
+    mapnik::save_map(*m->map_, filename, explicit_defaults);
     return;
 }
 
@@ -1496,31 +1348,25 @@ NAN_METHOD(Map::save)
  * @example
  * var xml = map.toXML();
  */
-NAN_METHOD(Map::toXML)
-{
+NAN_METHOD(Map::toXML) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
     bool explicit_defaults = false;
-    std::string map_string = mapnik::save_map_to_string(*m->map_,explicit_defaults);
+    std::string map_string = mapnik::save_map_to_string(*m->map_, explicit_defaults);
     info.GetReturnValue().Set(Nan::New<v8::String>(map_string).ToLocalChecked());
 }
 
-NAN_METHOD(Map::zoomAll)
-{
+NAN_METHOD(Map::zoomAll) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
-    try
-    {
+    try {
         m->map_->zoom_all();
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         Nan::ThrowError(ex.what());
         return;
     }
     return;
 }
 
-NAN_METHOD(Map::zoomToBox)
-{
+NAN_METHOD(Map::zoomToBox) {
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
 
     double minx;
@@ -1528,10 +1374,8 @@ NAN_METHOD(Map::zoomToBox)
     double maxx;
     double maxy;
 
-    if (info.Length() == 1)
-    {
-        if (!info[0]->IsArray())
-        {
+    if (info.Length() == 1) {
+        if (!info[0]->IsArray()) {
             Nan::ThrowError("Must provide an array of: [minx,miny,maxx,maxy]");
             return;
         }
@@ -1541,37 +1385,31 @@ NAN_METHOD(Map::zoomToBox)
         maxx = a->Get(2)->NumberValue();
         maxy = a->Get(3)->NumberValue();
 
-    }
-    else if (info.Length() != 4)
-    {
+    } else if (info.Length() != 4) {
         Nan::ThrowError("Must provide 4 arguments: minx,miny,maxx,maxy");
         return;
-    }
-    else if (info[0]->IsNumber() &&
+    } else if (info[0]->IsNumber() &&
                info[1]->IsNumber() &&
                info[2]->IsNumber() &&
-               info[3]->IsNumber())
-    {
+               info[3]->IsNumber()) {
         minx = info[0]->NumberValue();
         miny = info[1]->NumberValue();
         maxx = info[2]->NumberValue();
         maxy = info[3]->NumberValue();
-    }
-    else
-    {
+    } else {
         Nan::ThrowError("If you are providing 4 arguments: minx,miny,maxx,maxy - they must be all numbers");
         return;
     }
 
-    mapnik::box2d<double> box(minx,miny,maxx,maxy);
+    mapnik::box2d<double> box(minx, miny, maxx, maxy);
     m->map_->zoom_to_box(box);
     return;
 }
 
 struct image_baton_t {
     uv_work_t request;
-    Map *m;
-    Image *im;
+    Map* m;
+    Image* im;
     int buffer_size; // TODO - no effect until mapnik::request is used
     double scale_factor;
     double scale_denominator;
@@ -1581,22 +1419,21 @@ struct image_baton_t {
     bool error;
     std::string error_name;
     Nan::Persistent<v8::Function> cb;
-    image_baton_t() :
-      buffer_size(0),
-      scale_factor(1.0),
-      scale_denominator(0.0),
-      variables(),
-      offset_x(0),
-      offset_y(0),
-      error(false),
-      error_name() {}
+    image_baton_t() : buffer_size(0),
+                      scale_factor(1.0),
+                      scale_denominator(0.0),
+                      variables(),
+                      offset_x(0),
+                      offset_y(0),
+                      error(false),
+                      error_name() {}
 };
 
 #if defined(GRID_RENDERER)
 struct grid_baton_t {
     uv_work_t request;
-    Map *m;
-    Grid *g;
+    Map* m;
+    Grid* g;
     std::size_t layer_idx;
     int buffer_size; // TODO - no effect until mapnik::request is used
     double scale_factor;
@@ -1607,23 +1444,22 @@ struct grid_baton_t {
     bool error;
     std::string error_name;
     Nan::Persistent<v8::Function> cb;
-    grid_baton_t() :
-      layer_idx(-1),
-      buffer_size(0),
-      scale_factor(1.0),
-      scale_denominator(0.0),
-      variables(),
-      offset_x(0),
-      offset_y(0),
-      error(false),
-      error_name() {}
+    grid_baton_t() : layer_idx(-1),
+                     buffer_size(0),
+                     scale_factor(1.0),
+                     scale_denominator(0.0),
+                     variables(),
+                     offset_x(0),
+                     offset_y(0),
+                     error(false),
+                     error_name() {}
 };
 #endif
 
 struct vector_tile_baton_t {
     uv_work_t request;
-    Map *m;
-    VectorTile *d;
+    Map* m;
+    VectorTile* d;
     double area_threshold;
     double scale_factor;
     double scale_denominator;
@@ -1641,22 +1477,21 @@ struct vector_tile_baton_t {
     std::launch threading_mode;
     std::string error_name;
     Nan::Persistent<v8::Function> cb;
-    vector_tile_baton_t() :
-        area_threshold(0.1),
-        scale_factor(1.0),
-        scale_denominator(0.0),
-        variables(),
-        offset_x(0),
-        offset_y(0),
-        image_format("webp"),
-        scaling_method(mapnik::SCALING_BILINEAR),
-        simplify_distance(0.0),
-        error(false),
-        strictly_simple(true),
-        multi_polygon_union(false),
-        fill_type(mapnik::vector_tile_impl::positive_fill),
-        process_all_rings(false),
-        threading_mode(std::launch::deferred) {}
+    vector_tile_baton_t() : area_threshold(0.1),
+                            scale_factor(1.0),
+                            scale_denominator(0.0),
+                            variables(),
+                            offset_x(0),
+                            offset_y(0),
+                            image_format("webp"),
+                            scaling_method(mapnik::SCALING_BILINEAR),
+                            simplify_distance(0.0),
+                            error(false),
+                            strictly_simple(true),
+                            multi_polygon_union(false),
+                            fill_type(mapnik::vector_tile_impl::positive_fill),
+                            process_all_rings(false),
+                            threading_mode(std::launch::deferred) {}
 };
 
 /**
@@ -1719,8 +1554,7 @@ struct vector_tile_baton_t {
  *     console.log(vtile); // => vector tile object with data from xml
  * });
  */
-NAN_METHOD(Map::render)
-{
+NAN_METHOD(Map::render) {
     // ensure at least 2 args
     if (info.Length() < 2) {
         Nan::ThrowTypeError("requires at least two arguments, a renderable mapnik object, and a callback");
@@ -1734,15 +1568,14 @@ NAN_METHOD(Map::render)
     }
 
     // ensure function callback
-    if (!info[info.Length()-1]->IsFunction()) {
+    if (!info[info.Length() - 1]->IsFunction()) {
         Nan::ThrowTypeError("last argument must be a callback function");
         return;
     }
 
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
 
-    try
-    {
+    try {
         // parse options
 
         // defaults
@@ -1818,7 +1651,7 @@ NAN_METHOD(Map::render)
 
         if (Nan::New(Image::constructor)->HasInstance(obj)) {
 
-            image_baton_t *closure = new image_baton_t();
+            image_baton_t* closure = new image_baton_t();
             closure->request.data = closure;
             closure->m = m;
             closure->im = Nan::ObjectWrap::Unwrap<Image>(obj);
@@ -1830,19 +1663,16 @@ NAN_METHOD(Map::render)
             closure->offset_y = offset_y;
             closure->error = false;
 
-            if (options->Has(Nan::New("variables").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("variables").ToLocalChecked())) {
                 v8::Local<v8::Value> bind_opt = options->Get(Nan::New("variables").ToLocalChecked());
-                if (!bind_opt->IsObject())
-                {
+                if (!bind_opt->IsObject()) {
                     delete closure;
                     Nan::ThrowTypeError("optional arg 'variables' must be an object");
                     return;
                 }
-                object_to_container(closure->variables,bind_opt->ToObject());
+                object_to_container(closure->variables, bind_opt->ToObject());
             }
-            if (!m->acquire())
-            {
+            if (!m->acquire()) {
                 delete closure;
                 Nan::ThrowTypeError("render: Map currently in use by another thread. Consider using a map pool.");
                 return;
@@ -1854,7 +1684,7 @@ NAN_METHOD(Map::render)
 #if defined(GRID_RENDERER)
         else if (Nan::New(Grid::constructor)->HasInstance(obj)) {
 
-            Grid * g = Nan::ObjectWrap::Unwrap<Grid>(obj);
+            Grid* g = Nan::ObjectWrap::Unwrap<Grid>(obj);
 
             std::size_t layer_idx = 0;
 
@@ -1867,7 +1697,7 @@ NAN_METHOD(Map::render)
                 std::vector<mapnik::layer> const& layers = m->map_->layers();
 
                 v8::Local<v8::Value> layer_id = options->Get(Nan::New("layer").ToLocalChecked());
-                if (! (layer_id->IsString() || layer_id->IsNumber()) ) {
+                if (!(layer_id->IsString() || layer_id->IsNumber())) {
                     Nan::ThrowTypeError("'layer' option required for grid rendering and must be either a layer name(string) or layer index (integer)");
                     return;
                 }
@@ -1875,19 +1705,16 @@ NAN_METHOD(Map::render)
                 if (layer_id->IsString()) {
                     bool found = false;
                     unsigned int idx(0);
-                    std::string const & layer_name = TOSTR(layer_id);
-                    for (mapnik::layer const& lyr : layers)
-                    {
-                        if (lyr.name() == layer_name)
-                        {
+                    std::string const& layer_name = TOSTR(layer_id);
+                    for (mapnik::layer const& lyr : layers) {
+                        if (lyr.name() == layer_name) {
                             found = true;
                             layer_idx = idx;
                             break;
                         }
                         ++idx;
                     }
-                    if (!found)
-                    {
+                    if (!found) {
                         std::ostringstream s;
                         s << "Layer name '" << layer_name << "' not found";
                         Nan::ThrowTypeError(s.str().c_str());
@@ -1900,12 +1727,9 @@ NAN_METHOD(Map::render)
                     if (layer_idx >= layer_num) {
                         std::ostringstream s;
                         s << "Zero-based layer index '" << layer_idx << "' not valid, ";
-                        if (layer_num > 0)
-                        {
+                        if (layer_num > 0) {
                             s << "only '" << layer_num << "' layers exist in map";
-                        }
-                        else
-                        {
+                        } else {
                             s << "no layers found in map";
                         }
                         Nan::ThrowTypeError(s.str().c_str());
@@ -1926,25 +1750,23 @@ NAN_METHOD(Map::render)
                 unsigned int num_fields = a->Length();
                 while (i < num_fields) {
                     v8::Local<v8::Value> name = a->Get(i);
-                    if (name->IsString()){
+                    if (name->IsString()) {
                         g->get()->add_field(TOSTR(name));
                     }
                     i++;
                 }
             }
 
-            grid_baton_t *closure = new grid_baton_t();
+            grid_baton_t* closure = new grid_baton_t();
 
-            if (options->Has(Nan::New("variables").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("variables").ToLocalChecked())) {
                 v8::Local<v8::Value> bind_opt = options->Get(Nan::New("variables").ToLocalChecked());
-                if (!bind_opt->IsObject())
-                {
+                if (!bind_opt->IsObject()) {
                     delete closure;
                     Nan::ThrowTypeError("optional arg 'variables' must be an object");
                     return;
                 }
-                object_to_container(closure->variables,bind_opt->ToObject());
+                object_to_container(closure->variables, bind_opt->ToObject());
             }
 
             closure->request.data = closure;
@@ -1958,8 +1780,7 @@ NAN_METHOD(Map::render)
             closure->offset_x = offset_x;
             closure->offset_y = offset_y;
             closure->error = false;
-            if (!m->acquire())
-            {
+            if (!m->acquire()) {
                 delete closure;
                 Nan::ThrowTypeError("render: Map currently in use by another thread. Consider using a map pool.");
                 return;
@@ -1968,24 +1789,20 @@ NAN_METHOD(Map::render)
             uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderGrid, (uv_after_work_cb)EIO_AfterRenderGrid);
         }
 #endif
-        else if (Nan::New(VectorTile::constructor)->HasInstance(obj))
-        {
+        else if (Nan::New(VectorTile::constructor)->HasInstance(obj)) {
 
-            vector_tile_baton_t *closure = new vector_tile_baton_t();
+            vector_tile_baton_t* closure = new vector_tile_baton_t();
 
-            if (options->Has(Nan::New("image_scaling").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("image_scaling").ToLocalChecked())) {
                 v8::Local<v8::Value> param_val = options->Get(Nan::New("image_scaling").ToLocalChecked());
-                if (!param_val->IsString())
-                {
+                if (!param_val->IsString()) {
                     delete closure;
                     Nan::ThrowTypeError("option 'image_scaling' must be a string");
                     return;
                 }
                 std::string image_scaling = TOSTR(param_val);
                 boost::optional<mapnik::scaling_method_e> method = mapnik::scaling_method_from_string(image_scaling);
-                if (!method)
-                {
+                if (!method) {
                     delete closure;
                     Nan::ThrowTypeError("option 'image_scaling' must be a string and a valid scaling method (e.g 'bilinear')");
                     return;
@@ -1993,11 +1810,9 @@ NAN_METHOD(Map::render)
                 closure->scaling_method = *method;
             }
 
-            if (options->Has(Nan::New("image_format").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("image_format").ToLocalChecked())) {
                 v8::Local<v8::Value> param_val = options->Get(Nan::New("image_format").ToLocalChecked());
-                if (!param_val->IsString())
-                {
+                if (!param_val->IsString()) {
                     delete closure;
                     Nan::ThrowTypeError("option 'image_format' must be a string");
                     return;
@@ -2005,29 +1820,24 @@ NAN_METHOD(Map::render)
                 closure->image_format = TOSTR(param_val);
             }
 
-            if (options->Has(Nan::New("area_threshold").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("area_threshold").ToLocalChecked())) {
                 v8::Local<v8::Value> param_val = options->Get(Nan::New("area_threshold").ToLocalChecked());
-                if (!param_val->IsNumber())
-                {
+                if (!param_val->IsNumber()) {
                     delete closure;
                     Nan::ThrowTypeError("option 'area_threshold' must be a number");
                     return;
                 }
                 closure->area_threshold = param_val->NumberValue();
-                if (closure->area_threshold < 0.0)
-                {
+                if (closure->area_threshold < 0.0) {
                     delete closure;
                     Nan::ThrowTypeError("option 'area_threshold' must not be a negative number");
                     return;
                 }
             }
 
-            if (options->Has(Nan::New("strictly_simple").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("strictly_simple").ToLocalChecked())) {
                 v8::Local<v8::Value> param_val = options->Get(Nan::New("strictly_simple").ToLocalChecked());
-                if (!param_val->IsBoolean())
-                {
+                if (!param_val->IsBoolean()) {
                     delete closure;
                     Nan::ThrowTypeError("option 'strictly_simple' must be a boolean");
                     return;
@@ -2035,11 +1845,9 @@ NAN_METHOD(Map::render)
                 closure->strictly_simple = param_val->BooleanValue();
             }
 
-            if (options->Has(Nan::New("multi_polygon_union").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("multi_polygon_union").ToLocalChecked())) {
                 v8::Local<v8::Value> param_val = options->Get(Nan::New("multi_polygon_union").ToLocalChecked());
-                if (!param_val->IsBoolean())
-                {
+                if (!param_val->IsBoolean()) {
                     delete closure;
                     Nan::ThrowTypeError("option 'multi_polygon_union' must be a boolean");
                     return;
@@ -2047,29 +1855,24 @@ NAN_METHOD(Map::render)
                 closure->multi_polygon_union = param_val->BooleanValue();
             }
 
-            if (options->Has(Nan::New("fill_type").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("fill_type").ToLocalChecked())) {
                 v8::Local<v8::Value> param_val = options->Get(Nan::New("fill_type").ToLocalChecked());
-                if (!param_val->IsNumber())
-                {
+                if (!param_val->IsNumber()) {
                     delete closure;
                     Nan::ThrowTypeError("option 'fill_type' must be an unsigned integer");
                     return;
                 }
                 closure->fill_type = static_cast<mapnik::vector_tile_impl::polygon_fill_type>(param_val->IntegerValue());
-                if (closure->fill_type < 0 || closure->fill_type >= mapnik::vector_tile_impl::polygon_fill_type_max)
-                {
+                if (closure->fill_type < 0 || closure->fill_type >= mapnik::vector_tile_impl::polygon_fill_type_max) {
                     delete closure;
                     Nan::ThrowTypeError("optional arg 'fill_type' out of possible range");
                     return;
                 }
             }
 
-            if (options->Has(Nan::New("threading_mode").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("threading_mode").ToLocalChecked())) {
                 v8::Local<v8::Value> param_val = options->Get(Nan::New("threading_mode").ToLocalChecked());
-                if (!param_val->IsNumber())
-                {
+                if (!param_val->IsNumber()) {
                     delete closure;
                     Nan::ThrowTypeError("option 'threading_mode' must be an unsigned integer");
                     return;
@@ -2077,49 +1880,41 @@ NAN_METHOD(Map::render)
                 closure->threading_mode = static_cast<std::launch>(param_val->IntegerValue());
                 if (closure->threading_mode != std::launch::async &&
                     closure->threading_mode != std::launch::deferred &&
-                    closure->threading_mode != (std::launch::async | std::launch::deferred))
-                {
+                    closure->threading_mode != (std::launch::async | std::launch::deferred)) {
                     delete closure;
                     Nan::ThrowTypeError("optional arg 'threading_mode' value passed is invalid");
                     return;
                 }
             }
 
-            if (options->Has(Nan::New("simplify_distance").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("simplify_distance").ToLocalChecked())) {
                 v8::Local<v8::Value> param_val = options->Get(Nan::New("simplify_distance").ToLocalChecked());
-                if (!param_val->IsNumber())
-                {
+                if (!param_val->IsNumber()) {
                     delete closure;
                     Nan::ThrowTypeError("option 'simplify_distance' must be an floating point number");
                     return;
                 }
                 closure->simplify_distance = param_val->NumberValue();
-                if (closure->simplify_distance < 0)
-                {
+                if (closure->simplify_distance < 0) {
                     delete closure;
                     Nan::ThrowTypeError("option 'simplify_distance' can not be negative");
                     return;
                 }
             }
 
-            if (options->Has(Nan::New("variables").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("variables").ToLocalChecked())) {
                 v8::Local<v8::Value> bind_opt = options->Get(Nan::New("variables").ToLocalChecked());
-                if (!bind_opt->IsObject())
-                {
+                if (!bind_opt->IsObject()) {
                     delete closure;
                     Nan::ThrowTypeError("optional arg 'variables' must be an object");
                     return;
                 }
-                object_to_container(closure->variables,bind_opt->ToObject());
+                object_to_container(closure->variables, bind_opt->ToObject());
             }
 
-            if (options->Has(Nan::New("process_all_rings").ToLocalChecked()))
-            {
+            if (options->Has(Nan::New("process_all_rings").ToLocalChecked())) {
                 v8::Local<v8::Value> param_val = options->Get(Nan::New("process_all_rings").ToLocalChecked());
-                if (!param_val->IsBoolean())
-                {
+                if (!param_val->IsBoolean()) {
                     delete closure;
                     Nan::ThrowTypeError("option 'process_all_rings' must be a boolean");
                     return;
@@ -2136,26 +1931,21 @@ NAN_METHOD(Map::render)
             closure->offset_x = offset_x;
             closure->offset_y = offset_y;
             closure->error = false;
-            if (!m->acquire())
-            {
+            if (!m->acquire()) {
                 delete closure;
                 Nan::ThrowTypeError("render: Map currently in use by another thread. Consider using a map pool.");
                 return;
             }
             closure->cb.Reset(info[info.Length() - 1].As<v8::Function>());
             uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderVectorTile, (uv_after_work_cb)EIO_AfterRenderVectorTile);
-        }
-        else
-        {
+        } else {
             Nan::ThrowTypeError("renderable mapnik object expected");
             return;
         }
 
         m->Ref();
         return;
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         // I am not quite sure it is possible to put a test in to cover an exception here
         /* LCOV_EXCL_START */
         Nan::ThrowTypeError(ex.what());
@@ -2164,11 +1954,9 @@ NAN_METHOD(Map::render)
     }
 }
 
-void Map::EIO_RenderVectorTile(uv_work_t* req)
-{
-    vector_tile_baton_t *closure = static_cast<vector_tile_baton_t *>(req->data);
-    try
-    {
+void Map::EIO_RenderVectorTile(uv_work_t* req) {
+    vector_tile_baton_t* closure = static_cast<vector_tile_baton_t*>(req->data);
+    try {
         mapnik::Map const& map = *closure->m->get();
 
         mapnik::vector_tile_impl::processor ren(map);
@@ -2187,28 +1975,22 @@ void Map::EIO_RenderVectorTile(uv_work_t* req)
                         closure->scale_denominator,
                         closure->offset_x,
                         closure->offset_y);
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         closure->error = true;
         closure->error_name = ex.what();
     }
 }
 
-void Map::EIO_AfterRenderVectorTile(uv_work_t* req)
-{
+void Map::EIO_AfterRenderVectorTile(uv_work_t* req) {
     Nan::HandleScope scope;
-    vector_tile_baton_t *closure = static_cast<vector_tile_baton_t *>(req->data);
+    vector_tile_baton_t* closure = static_cast<vector_tile_baton_t*>(req->data);
     closure->m->release();
 
-    if (closure->error)
-    {
-        v8::Local<v8::Value> argv[1] = { Nan::Error(closure->error_name.c_str()) };
+    if (closure->error) {
+        v8::Local<v8::Value> argv[1] = {Nan::Error(closure->error_name.c_str())};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
-    }
-    else
-    {
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->d->handle() };
+    } else {
+        v8::Local<v8::Value> argv[2] = {Nan::Null(), closure->d->handle()};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
@@ -2219,29 +2001,25 @@ void Map::EIO_AfterRenderVectorTile(uv_work_t* req)
 }
 
 #if defined(GRID_RENDERER)
-void Map::EIO_RenderGrid(uv_work_t* req)
-{
+void Map::EIO_RenderGrid(uv_work_t* req) {
 
-    grid_baton_t *closure = static_cast<grid_baton_t *>(req->data);
+    grid_baton_t* closure = static_cast<grid_baton_t*>(req->data);
 
     std::vector<mapnik::layer> const& layers = closure->m->map_->layers();
 
-    try
-    {
+    try {
         // copy property names
         std::set<std::string> attributes = closure->g->get()->get_fields();
 
         // todo - make this a static constant
         std::string known_id_key = "__id__";
-        if (attributes.find(known_id_key) != attributes.end())
-        {
+        if (attributes.find(known_id_key) != attributes.end()) {
             attributes.erase(known_id_key);
         }
 
         std::string join_field = closure->g->get()->get_key();
         if (known_id_key != join_field &&
-            attributes.find(join_field) == attributes.end())
-        {
+            attributes.find(join_field) == attributes.end()) {
             attributes.insert(join_field);
         }
 
@@ -2251,28 +2029,25 @@ void Map::EIO_RenderGrid(uv_work_t* req)
                                                 closure->offset_x,
                                                 closure->offset_y);
         mapnik::layer const& layer = layers[closure->layer_idx];
-        ren.apply(layer,attributes,closure->scale_denominator);
-    }
-    catch (std::exception const& ex)
-    {
+        ren.apply(layer, attributes, closure->scale_denominator);
+    } catch (std::exception const& ex) {
         closure->error = true;
         closure->error_name = ex.what();
     }
 }
 
-void Map::EIO_AfterRenderGrid(uv_work_t* req)
-{
+void Map::EIO_AfterRenderGrid(uv_work_t* req) {
     Nan::HandleScope scope;
-    grid_baton_t *closure = static_cast<grid_baton_t *>(req->data);
+    grid_baton_t* closure = static_cast<grid_baton_t*>(req->data);
     closure->m->release();
 
     if (closure->error) {
         // TODO - add more attributes
         // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error
-        v8::Local<v8::Value> argv[1] = { Nan::Error(closure->error_name.c_str()) };
+        v8::Local<v8::Value> argv[1] = {Nan::Error(closure->error_name.c_str())};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     } else {
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->g->handle() };
+        v8::Local<v8::Value> argv[2] = {Nan::Null(), closure->g->handle()};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
@@ -2283,8 +2058,7 @@ void Map::EIO_AfterRenderGrid(uv_work_t* req)
 }
 #endif
 
-struct agg_renderer_visitor
-{
+struct agg_renderer_visitor {
     agg_renderer_visitor(mapnik::Map const& m,
                          mapnik::request const& req,
                          mapnik::attributes const& vars,
@@ -2300,15 +2074,13 @@ struct agg_renderer_visitor
           offset_y_(offset_y),
           scale_denominator_(scale_denominator) {}
 
-    void operator() (mapnik::image_rgba8 & pixmap)
-    {
-        mapnik::agg_renderer<mapnik::image_rgba8> ren(m_,req_,vars_,pixmap,scale_factor_,offset_x_,offset_y_);
+    void operator()(mapnik::image_rgba8& pixmap) {
+        mapnik::agg_renderer<mapnik::image_rgba8> ren(m_, req_, vars_, pixmap, scale_factor_, offset_x_, offset_y_);
         ren.apply(scale_denominator_);
     }
 
     template <typename T>
-    void operator() (T &)
-    {
+    void operator()(T&) {
         throw std::runtime_error("This image type is not currently supported for rendering.");
     }
 
@@ -2322,14 +2094,12 @@ struct agg_renderer_visitor
     double scale_denominator_;
 };
 
-void Map::EIO_RenderImage(uv_work_t* req)
-{
-    image_baton_t *closure = static_cast<image_baton_t *>(req->data);
+void Map::EIO_RenderImage(uv_work_t* req) {
+    image_baton_t* closure = static_cast<image_baton_t*>(req->data);
 
-    try
-    {
+    try {
         mapnik::Map const& map = *closure->m->map_;
-        mapnik::request m_req(map.width(),map.height(),map.get_current_extent());
+        mapnik::request m_req(map.width(), map.height(), map.get_current_extent());
         m_req.set_buffer_size(closure->buffer_size);
         agg_renderer_visitor visit(map,
                                    m_req,
@@ -2339,25 +2109,22 @@ void Map::EIO_RenderImage(uv_work_t* req)
                                    closure->offset_y,
                                    closure->scale_denominator);
         mapnik::util::apply_visitor(visit, *closure->im->get());
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         closure->error = true;
         closure->error_name = ex.what();
     }
 }
 
-void Map::EIO_AfterRenderImage(uv_work_t* req)
-{
+void Map::EIO_AfterRenderImage(uv_work_t* req) {
     Nan::HandleScope scope;
-    image_baton_t *closure = static_cast<image_baton_t *>(req->data);
+    image_baton_t* closure = static_cast<image_baton_t*>(req->data);
     closure->m->release();
 
     if (closure->error) {
-        v8::Local<v8::Value> argv[1] = { Nan::Error(closure->error_name.c_str()) };
+        v8::Local<v8::Value> argv[1] = {Nan::Error(closure->error_name.c_str())};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     } else {
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), closure->im->handle() };
+        v8::Local<v8::Value> argv[2] = {Nan::Null(), closure->im->handle()};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }
 
@@ -2369,7 +2136,7 @@ void Map::EIO_AfterRenderImage(uv_work_t* req)
 
 typedef struct {
     uv_work_t request;
-    Map *m;
+    Map* m;
     std::string format;
     std::string output;
     palette_ptr palette;
@@ -2383,8 +2150,7 @@ typedef struct {
     Nan::Persistent<v8::Function> cb;
 } render_file_baton_t;
 
-NAN_METHOD(Map::renderFile)
-{
+NAN_METHOD(Map::renderFile) {
     if (info.Length() < 1 || !info[0]->IsString()) {
         Nan::ThrowTypeError("first argument must be a path to a file to save");
         return;
@@ -2397,7 +2163,7 @@ NAN_METHOD(Map::renderFile)
     palette_ptr palette;
     int buffer_size = 0;
 
-    v8::Local<v8::Value> callback = info[info.Length()-1];
+    v8::Local<v8::Value> callback = info[info.Length() - 1];
 
     if (!callback->IsFunction()) {
         Nan::ThrowTypeError("last argument must be a callback function");
@@ -2408,8 +2174,7 @@ NAN_METHOD(Map::renderFile)
 
     if (!info[1]->IsFunction() && info[1]->IsObject()) {
         options = info[1]->ToObject();
-        if (options->Has(Nan::New("format").ToLocalChecked()))
-        {
+        if (options->Has(Nan::New("format").ToLocalChecked())) {
             v8::Local<v8::Value> format_opt = options->Get(Nan::New("format").ToLocalChecked());
             if (!format_opt->IsString()) {
                 Nan::ThrowTypeError("'format' must be a String");
@@ -2419,8 +2184,7 @@ NAN_METHOD(Map::renderFile)
             format = TOSTR(format_opt);
         }
 
-        if (options->Has(Nan::New("palette").ToLocalChecked()))
-        {
+        if (options->Has(Nan::New("palette").ToLocalChecked())) {
             v8::Local<v8::Value> format_opt = options->Get(Nan::New("palette").ToLocalChecked());
             if (!format_opt->IsObject()) {
                 Nan::ThrowTypeError("'palette' must be an object");
@@ -2484,18 +2248,16 @@ NAN_METHOD(Map::renderFile)
         }
     }
 
-    render_file_baton_t *closure = new render_file_baton_t();
+    render_file_baton_t* closure = new render_file_baton_t();
 
-    if (options->Has(Nan::New("variables").ToLocalChecked()))
-    {
+    if (options->Has(Nan::New("variables").ToLocalChecked())) {
         v8::Local<v8::Value> bind_opt = options->Get(Nan::New("variables").ToLocalChecked());
-        if (!bind_opt->IsObject())
-        {
+        if (!bind_opt->IsObject()) {
             delete closure;
             Nan::ThrowTypeError("optional arg 'variables' must be an object");
             return;
         }
-        object_to_container(closure->variables,bind_opt->ToObject());
+        object_to_container(closure->variables, bind_opt->ToObject());
     }
 
     if (format == "pdf" || format == "svg" || format == "ps" || format == "ARGB32" || format == "RGB24") {
@@ -2512,8 +2274,7 @@ NAN_METHOD(Map::renderFile)
         closure->use_cairo = false;
     }
 
-    if (!m->acquire())
-    {
+    if (!m->acquire()) {
         delete closure;
         Nan::ThrowTypeError("render: Map currently in use by another thread. Consider using a map pool.");
         return;
@@ -2535,90 +2296,76 @@ NAN_METHOD(Map::renderFile)
     m->Ref();
 
     return;
-
 }
 
-void Map::EIO_RenderFile(uv_work_t* req)
-{
-    render_file_baton_t *closure = static_cast<render_file_baton_t *>(req->data);
+void Map::EIO_RenderFile(uv_work_t* req) {
+    render_file_baton_t* closure = static_cast<render_file_baton_t*>(req->data);
 
-    try
-    {
-        if(closure->use_cairo)
-        {
+    try {
+        if (closure->use_cairo) {
 #if defined(HAVE_CAIRO)
             // https://github.com/mapnik/mapnik/issues/1930
-            mapnik::save_to_cairo_file(*closure->m->map_,closure->output,closure->format,closure->scale_factor,closure->scale_denominator);
+            mapnik::save_to_cairo_file(*closure->m->map_, closure->output, closure->format, closure->scale_factor, closure->scale_denominator);
 #else
 #endif
-        }
-        else
-        {
-            mapnik::image_rgba8 im(closure->m->map_->width(),closure->m->map_->height());
+        } else {
+            mapnik::image_rgba8 im(closure->m->map_->width(), closure->m->map_->height());
             mapnik::Map const& map = *closure->m->map_;
-            mapnik::request m_req(map.width(),map.height(),map.get_current_extent());
+            mapnik::request m_req(map.width(), map.height(), map.get_current_extent());
             m_req.set_buffer_size(closure->buffer_size);
             mapnik::agg_renderer<mapnik::image_rgba8> ren(map,
-                                                   m_req,
-                                                   closure->variables,
-                                                   im,
-                                                   closure->scale_factor);
+                                                          m_req,
+                                                          closure->variables,
+                                                          im,
+                                                          closure->scale_factor);
             ren.apply(closure->scale_denominator);
 
             if (closure->palette.get()) {
-                mapnik::save_to_file(im,closure->output,*closure->palette);
+                mapnik::save_to_file(im, closure->output, *closure->palette);
             } else {
-                mapnik::save_to_file(im,closure->output);
+                mapnik::save_to_file(im, closure->output);
             }
         }
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         closure->error = true;
         closure->error_name = ex.what();
     }
 }
 
-void Map::EIO_AfterRenderFile(uv_work_t* req)
-{
+void Map::EIO_AfterRenderFile(uv_work_t* req) {
     Nan::HandleScope scope;
-    render_file_baton_t *closure = static_cast<render_file_baton_t *>(req->data);
+    render_file_baton_t* closure = static_cast<render_file_baton_t*>(req->data);
     closure->m->release();
 
     if (closure->error) {
-        v8::Local<v8::Value> argv[1] = { Nan::Error(closure->error_name.c_str()) };
+        v8::Local<v8::Value> argv[1] = {Nan::Error(closure->error_name.c_str())};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     } else {
-        v8::Local<v8::Value> argv[1] = { Nan::Null() };
+        v8::Local<v8::Value> argv[1] = {Nan::Null()};
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
     }
 
     closure->m->Unref();
     closure->cb.Reset();
     delete closure;
-
 }
 
 // TODO - add support for grids
-NAN_METHOD(Map::renderSync)
-{
+NAN_METHOD(Map::renderSync) {
     std::string format = "png";
     palette_ptr palette;
     double scale_factor = 1.0;
     double scale_denominator = 0.0;
     int buffer_size = 0;
 
-    if (info.Length() >= 1)
-    {
-        if (!info[0]->IsObject())
-        {
+    if (info.Length() >= 1) {
+        if (!info[0]->IsObject()) {
             Nan::ThrowTypeError("first argument is optional, but if provided must be an object, eg. {format: 'pdf'}");
             return;
         }
 
         v8::Local<v8::Object> options = info[0]->ToObject();
-        if (options->Has(Nan::New("format").ToLocalChecked()))
-        {
+        if (options->Has(Nan::New("format").ToLocalChecked())) {
             v8::Local<v8::Value> format_opt = options->Get(Nan::New("format").ToLocalChecked());
             if (!format_opt->IsString()) {
                 Nan::ThrowTypeError("'format' must be a String");
@@ -2628,8 +2375,7 @@ NAN_METHOD(Map::renderSync)
             format = TOSTR(format_opt);
         }
 
-        if (options->Has(Nan::New("palette").ToLocalChecked()))
-        {
+        if (options->Has(Nan::New("palette").ToLocalChecked())) {
             v8::Local<v8::Value> format_opt = options->Get(Nan::New("palette").ToLocalChecked());
             if (!format_opt->IsObject()) {
                 Nan::ThrowTypeError("'palette' must be an object");
@@ -2674,35 +2420,29 @@ NAN_METHOD(Map::renderSync)
     }
 
     Map* m = Nan::ObjectWrap::Unwrap<Map>(info.Holder());
-    if (!m->acquire())
-    {
+    if (!m->acquire()) {
         Nan::ThrowTypeError("render: Map currently in use by another thread. Consider using a map pool.");
         return;
     }
     std::string s;
-    try
-    {
-        mapnik::image_rgba8 im(m->map_->width(),m->map_->height());
+    try {
+        mapnik::image_rgba8 im(m->map_->width(), m->map_->height());
         mapnik::Map const& map = *m->map_;
-        mapnik::request m_req(map.width(),map.height(),map.get_current_extent());
+        mapnik::request m_req(map.width(), map.height(), map.get_current_extent());
         m_req.set_buffer_size(buffer_size);
         mapnik::agg_renderer<mapnik::image_rgba8> ren(map,
-                                                   m_req,
-                                                   mapnik::attributes(),
-                                                   im,
-                                                   scale_factor);
+                                                      m_req,
+                                                      mapnik::attributes(),
+                                                      im,
+                                                      scale_factor);
         ren.apply(scale_denominator);
 
-        if (palette.get())
-        {
+        if (palette.get()) {
             s = save_to_string(im, format, *palette);
-        }
-        else {
+        } else {
             s = save_to_string(im, format);
         }
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         m->release();
         Nan::ThrowError(ex.what());
         return;
@@ -2711,8 +2451,7 @@ NAN_METHOD(Map::renderSync)
     info.GetReturnValue().Set(Nan::CopyBuffer((char*)s.data(), s.size()).ToLocalChecked());
 }
 
-NAN_METHOD(Map::renderFileSync)
-{
+NAN_METHOD(Map::renderFileSync) {
     if (info.Length() < 1 || !info[0]->IsString()) {
         Nan::ThrowTypeError("first argument must be a path to a file to save");
         return;
@@ -2730,15 +2469,14 @@ NAN_METHOD(Map::renderFileSync)
     std::string format = "png";
     palette_ptr palette;
 
-    if (info.Length() >= 2){
+    if (info.Length() >= 2) {
         if (!info[1]->IsObject()) {
             Nan::ThrowTypeError("second argument is optional, but if provided must be an object, eg. {format: 'pdf'}");
             return;
         }
 
         v8::Local<v8::Object> options = info[1].As<v8::Object>();
-        if (options->Has(Nan::New("format").ToLocalChecked()))
-        {
+        if (options->Has(Nan::New("format").ToLocalChecked())) {
             v8::Local<v8::Value> format_opt = options->Get(Nan::New("format").ToLocalChecked());
             if (!format_opt->IsString()) {
                 Nan::ThrowTypeError("'format' must be a String");
@@ -2748,8 +2486,7 @@ NAN_METHOD(Map::renderFileSync)
             format = TOSTR(format_opt);
         }
 
-        if (options->Has(Nan::New("palette").ToLocalChecked()))
-        {
+        if (options->Has(Nan::New("palette").ToLocalChecked())) {
             v8::Local<v8::Value> format_opt = options->Get(Nan::New("palette").ToLocalChecked());
             if (!format_opt->IsObject()) {
                 Nan::ThrowTypeError("'palette' must be an object");
@@ -2805,19 +2542,16 @@ NAN_METHOD(Map::renderFileSync)
             return;
         }
     }
-    if (!m->acquire())
-    {
+    if (!m->acquire()) {
         Nan::ThrowTypeError("render: Map currently in use by another thread. Consider using a map pool.");
         return;
     }
 
-    try
-    {
+    try {
 
-        if (format == "pdf" || format == "svg" || format =="ps" || format == "ARGB32" || format == "RGB24")
-        {
+        if (format == "pdf" || format == "svg" || format == "ps" || format == "ARGB32" || format == "RGB24") {
 #if defined(HAVE_CAIRO)
-            mapnik::save_to_cairo_file(*m->map_,output,format,scale_factor,scale_denominator);
+            mapnik::save_to_cairo_file(*m->map_, output, format, scale_factor, scale_denominator);
 #else
             std::ostringstream s("");
             s << "Cairo backend is not available, cannot write to " << format << "\n";
@@ -2825,32 +2559,26 @@ NAN_METHOD(Map::renderFileSync)
             Nan::ThrowError(s.str().c_str());
             return;
 #endif
-        }
-        else
-        {
-            mapnik::image_rgba8 im(m->map_->width(),m->map_->height());
+        } else {
+            mapnik::image_rgba8 im(m->map_->width(), m->map_->height());
             mapnik::Map const& map = *m->map_;
-            mapnik::request m_req(map.width(),map.height(),map.get_current_extent());
+            mapnik::request m_req(map.width(), map.height(), map.get_current_extent());
             m_req.set_buffer_size(buffer_size);
             mapnik::agg_renderer<mapnik::image_rgba8> ren(map,
-                                                   m_req,
-                                                   mapnik::attributes(),
-                                                   im,
-                                                   scale_factor);
+                                                          m_req,
+                                                          mapnik::attributes(),
+                                                          im,
+                                                          scale_factor);
 
             ren.apply(scale_denominator);
 
-            if (palette.get())
-            {
-                mapnik::save_to_file(im,output,*palette);
-            }
-            else {
-                mapnik::save_to_file(im,output);
+            if (palette.get()) {
+                mapnik::save_to_file(im, output, *palette);
+            } else {
+                mapnik::save_to_file(im, output);
             }
         }
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         m->release();
         Nan::ThrowError(ex.what());
         return;

--- a/src/mapnik_map.hpp
+++ b/src/mapnik_map.hpp
@@ -8,18 +8,17 @@
 #pragma GCC diagnostic pop
 
 // stl
-#include <string>
 #include <memory>
+#include <string>
 
-
-
-namespace mapnik { class Map; }
+namespace mapnik {
+class Map;
+}
 
 typedef std::shared_ptr<mapnik::Map> map_ptr;
 
-class Map: public Nan::ObjectWrap {
-public:
-
+class Map : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -93,7 +92,7 @@ public:
 
     inline map_ptr get() { return map_; }
 
-private:
+  private:
     ~Map();
     map_ptr map_;
     bool in_use_;

--- a/src/mapnik_memory_datasource.hpp
+++ b/src/mapnik_memory_datasource.hpp
@@ -9,12 +9,12 @@
 
 #include <mapnik/datasource.hpp>
 
+namespace mapnik {
+class transcoder;
+}
 
-
-namespace mapnik { class transcoder; }
-
-class MemoryDatasource: public Nan::ObjectWrap {
-public:
+class MemoryDatasource : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -29,7 +29,7 @@ public:
     MemoryDatasource();
     inline mapnik::datasource_ptr get() { return datasource_; }
 
-private:
+  private:
     ~MemoryDatasource();
     mapnik::datasource_ptr datasource_;
     unsigned int feature_id_;

--- a/src/mapnik_palette.cpp
+++ b/src/mapnik_palette.cpp
@@ -3,10 +3,10 @@
 #include "utils.hpp"
 
 // stl
-#include <vector>
 #include <iomanip>
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include <vector>
 
 Nan::Persistent<v8::FunctionTemplate> Palette::constructor;
 
@@ -24,9 +24,8 @@ void Palette::Initialize(v8::Local<v8::Object> target) {
     constructor.Reset(lcons);
 }
 
-Palette::Palette(std::string const& palette, mapnik::rgba_palette::palette_type type) :
-    Nan::ObjectWrap(),
-    palette_(std::make_shared<mapnik::rgba_palette>(palette, type)) {}
+Palette::Palette(std::string const& palette, mapnik::rgba_palette::palette_type type) : Nan::ObjectWrap(),
+                                                                                        palette_(std::make_shared<mapnik::rgba_palette>(palette, type)) {}
 
 Palette::~Palette() {
 }
@@ -48,20 +47,13 @@ NAN_METHOD(Palette::New) {
     if (info.Length() >= 2) {
         if (info[1]->IsString()) {
             std::string obj = TOSTR(info[1]);
-            if (obj == "rgba")
-            {
+            if (obj == "rgba") {
                 type = mapnik::rgba_palette::PALETTE_RGBA;
-            }
-            else if (obj == "rgb")
-            {
+            } else if (obj == "rgb") {
                 type = mapnik::rgba_palette::PALETTE_RGB;
-            }
-            else if (obj == "act")
-            {
+            } else if (obj == "act") {
                 type = mapnik::rgba_palette::PALETTE_ACT;
-            }
-            else
-            {
+            } else {
                 Nan::ThrowTypeError((std::string("unknown palette type: ") + obj).c_str());
                 return;
             }
@@ -73,38 +65,36 @@ NAN_METHOD(Palette::New) {
         return;
     }
 
-    try
-    {
+    try {
 
         Palette* p = new Palette(palette, type);
         p->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         Nan::ThrowError(ex.what());
         return;
     }
 }
 
-NAN_METHOD(Palette::ToString)
-{
+NAN_METHOD(Palette::ToString) {
     palette_ptr p = Nan::ObjectWrap::Unwrap<Palette>(info.Holder())->palette_;
 
     const std::vector<mapnik::rgb>& colors = p->palette();
     std::size_t length = colors.size();
-    #if MAPNIK_VERSION >= 300012
+#if MAPNIK_VERSION >= 300012
     const std::vector<unsigned>& alpha = p->alpha_table();
-    #else
+#else
     const std::vector<unsigned>& alpha = p->alphaTable();
-    #endif
+#endif
     std::size_t alphaLength = alpha.size();
 
     std::ostringstream str("");
     str << "[Palette " << length;
-    if (length == 1) str << " color";
-    else str << " colors";
+    if (length == 1)
+        str << " color";
+    else
+        str << " colors";
 
     str << std::hex << std::setfill('0');
 
@@ -120,17 +110,16 @@ NAN_METHOD(Palette::ToString)
     info.GetReturnValue().Set(Nan::New<v8::String>(str.str()).ToLocalChecked());
 }
 
-NAN_METHOD(Palette::ToBuffer)
-{
+NAN_METHOD(Palette::ToBuffer) {
     palette_ptr p = Nan::ObjectWrap::Unwrap<Palette>(info.Holder())->palette_;
 
     const std::vector<mapnik::rgb>& colors = p->palette();
     std::size_t length = colors.size();
-    #if MAPNIK_VERSION >= 300012
+#if MAPNIK_VERSION >= 300012
     const std::vector<unsigned>& alpha = p->alpha_table();
-    #else
+#else
     const std::vector<unsigned>& alpha = p->alphaTable();
-    #endif
+#endif
     std::size_t alphaLength = alpha.size();
 
     char palette[256 * 4];

--- a/src/mapnik_palette.hpp
+++ b/src/mapnik_palette.hpp
@@ -10,12 +10,10 @@
 #include <mapnik/palette.hpp>
 #include <memory>
 
-
-
 typedef std::shared_ptr<mapnik::rgba_palette> palette_ptr;
 
-class Palette: public Nan::ObjectWrap {
-public:
+class Palette : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
 
     explicit Palette(std::string const& palette, mapnik::rgba_palette::palette_type type);
@@ -26,7 +24,8 @@ public:
     static NAN_METHOD(ToBuffer);
 
     inline palette_ptr palette() { return palette_; }
-private:
+
+  private:
     ~Palette();
     palette_ptr palette_;
 };

--- a/src/mapnik_plugins.hpp
+++ b/src/mapnik_plugins.hpp
@@ -1,17 +1,14 @@
 #ifndef __NODE_MAPNIK_PLUGINS_H__
 #define __NODE_MAPNIK_PLUGINS_H__
 
-
 // mapnik
 #include <mapnik/datasource_cache.hpp>
 #include <mapnik/version.hpp>
 
 // stl
-#include <vector>
-#include <string>
 #include "utils.hpp"
-
-
+#include <string>
+#include <vector>
 
 namespace node_mapnik {
 
@@ -33,12 +30,10 @@ namespace node_mapnik {
  * @name datasources
  * @returns {Array<String>} list of plugins available to use
  */
-static inline NAN_METHOD(available_input_plugins)
-{
+static inline NAN_METHOD(available_input_plugins) {
     std::vector<std::string> names = mapnik::datasource_cache::instance().plugin_names();
     v8::Local<v8::Array> a = Nan::New<v8::Array>(names.size());
-    for (unsigned i = 0; i < names.size(); ++i)
-    {
+    for (unsigned i = 0; i < names.size(); ++i) {
         a->Set(i, Nan::New<v8::String>(names[i].c_str()).ToLocalChecked());
     }
     info.GetReturnValue().Set(a);
@@ -64,10 +59,8 @@ static inline NAN_METHOD(available_input_plugins)
  * @example
  * mapnik.registerDatasource(path.join(mapnik.settings.paths.input_plugins, 'geojson.input'));
  */
-static inline NAN_METHOD(register_datasource)
-{
-    if (info.Length() != 1 || !info[0]->IsString())
-    {
+static inline NAN_METHOD(register_datasource) {
+    if (info.Length() != 1 || !info[0]->IsString()) {
         Nan::ThrowTypeError("first argument must be a path to a mapnik input plugin (.input)");
         return;
     }
@@ -75,8 +68,7 @@ static inline NAN_METHOD(register_datasource)
     std::string path = TOSTR(info[0]);
     mapnik::datasource_cache::instance().register_datasource(path);
     std::vector<std::string> names_after = mapnik::datasource_cache::instance().plugin_names();
-    if (names_after.size() > names_before.size())
-    {
+    if (names_after.size() > names_before.size()) {
         info.GetReturnValue().Set(Nan::True());
         return;
     }
@@ -90,10 +82,8 @@ static inline NAN_METHOD(register_datasource)
  * @name registerDatasources
  * @param {Array<String>} list of paths to their respective datasources
  */
-static inline NAN_METHOD(register_datasources)
-{
-    if (info.Length() != 1 || !info[0]->IsString())
-    {
+static inline NAN_METHOD(register_datasources) {
+    if (info.Length() != 1 || !info[0]->IsString()) {
         Nan::ThrowTypeError("first argument must be a path to a directory of mapnik input plugins");
         return;
     }
@@ -101,15 +91,13 @@ static inline NAN_METHOD(register_datasources)
     std::string path = TOSTR(info[0]);
     mapnik::datasource_cache::instance().register_datasources(path);
     std::vector<std::string> names_after = mapnik::datasource_cache::instance().plugin_names();
-    if (names_after.size() > names_before.size())
-    {
+    if (names_after.size() > names_before.size()) {
         info.GetReturnValue().Set(Nan::True());
         return;
     }
     info.GetReturnValue().Set(Nan::False());
 }
 
-
-}
+} // namespace node_mapnik
 
 #endif // __NODE_MAPNIK_PLUGINS_H__

--- a/src/mapnik_projection.cpp
+++ b/src/mapnik_projection.cpp
@@ -39,18 +39,14 @@ void Projection::Initialize(v8::Local<v8::Object> target) {
     constructor.Reset(lcons);
 }
 
-Projection::Projection(std::string const& name, bool defer_init) :
-    Nan::ObjectWrap(),
-    projection_(std::make_shared<mapnik::projection>(name, defer_init)) {}
+Projection::Projection(std::string const& name, bool defer_init) : Nan::ObjectWrap(),
+                                                                   projection_(std::make_shared<mapnik::projection>(name, defer_init)) {}
 
-Projection::~Projection()
-{
+Projection::~Projection() {
 }
 
-NAN_METHOD(Projection::New)
-{
-    if (!info.IsConstructCall())
-    {
+NAN_METHOD(Projection::New) {
+    if (!info.IsConstructCall()) {
         Nan::ThrowError("Cannot call constructor as function, you need to use 'new' keyword");
         return;
     }
@@ -60,19 +56,15 @@ NAN_METHOD(Projection::New)
         return;
     }
     bool lazy = false;
-    if (info.Length() >= 2)
-    {
-        if (!info[1]->IsObject())
-        {
+    if (info.Length() >= 2) {
+        if (!info[1]->IsObject()) {
             Nan::ThrowTypeError("The second parameter provided should be an options object");
             return;
         }
         v8::Local<v8::Object> options = info[1].As<v8::Object>();
-        if (options->Has(Nan::New("lazy").ToLocalChecked()))
-        {
+        if (options->Has(Nan::New("lazy").ToLocalChecked())) {
             v8::Local<v8::Value> lazy_opt = options->Get(Nan::New("lazy").ToLocalChecked());
-            if (!lazy_opt->IsBoolean())
-            {
+            if (!lazy_opt->IsBoolean()) {
                 Nan::ThrowTypeError("'lazy' must be a Boolean");
                 return;
             }
@@ -80,15 +72,12 @@ NAN_METHOD(Projection::New)
         }
     }
 
-    try
-    {
+    try {
         Projection* p = new Projection(TOSTR(info[0]), lazy);
         p->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
         return;
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         Nan::ThrowError(ex.what());
         return;
     }
@@ -107,12 +96,10 @@ NAN_METHOD(Projection::New)
  * var long_lat_coords = [-122.33517, 47.63752];
  * var projected = merc.forward(long_lat_coords);
  */
-NAN_METHOD(Projection::forward)
-{
+NAN_METHOD(Projection::forward) {
     Projection* p = Nan::ObjectWrap::Unwrap<Projection>(info.Holder());
 
-    try
-    {
+    try {
         if (info.Length() != 1) {
             Nan::ThrowError("Must provide an array of either [x,y] or [minx,miny,maxx,maxy]");
             return;
@@ -123,41 +110,36 @@ NAN_METHOD(Projection::forward)
             }
             v8::Local<v8::Array> a = info[0].As<v8::Array>();
             unsigned int array_length = a->Length();
-            if (array_length == 2)
-            {
+            if (array_length == 2) {
                 double x = a->Get(0)->NumberValue();
                 double y = a->Get(1)->NumberValue();
-                p->projection_->forward(x,y);
+                p->projection_->forward(x, y);
                 v8::Local<v8::Array> arr = Nan::New<v8::Array>(2);
                 arr->Set(0, Nan::New(x));
                 arr->Set(1, Nan::New(y));
                 info.GetReturnValue().Set(arr);
-            }
-            else if (array_length == 4)
-            {
+            } else if (array_length == 4) {
                 double ulx, uly, urx, ury, lrx, lry, llx, lly;
                 ulx = llx = a->Get(0)->NumberValue();
                 lry = lly = a->Get(1)->NumberValue();
                 lrx = urx = a->Get(2)->NumberValue();
                 uly = ury = a->Get(3)->NumberValue();
-                p->projection_->forward(ulx,uly);
-                p->projection_->forward(urx,ury);
-                p->projection_->forward(lrx,lry);
-                p->projection_->forward(llx,lly);
+                p->projection_->forward(ulx, uly);
+                p->projection_->forward(urx, ury);
+                p->projection_->forward(lrx, lry);
+                p->projection_->forward(llx, lly);
                 v8::Local<v8::Array> arr = Nan::New<v8::Array>(4);
-                arr->Set(0, Nan::New(std::min(ulx,llx)));
-                arr->Set(1, Nan::New(std::min(lry,lly)));
-                arr->Set(2, Nan::New(std::max(urx,lrx)));
-                arr->Set(3, Nan::New(std::max(ury,uly)));
+                arr->Set(0, Nan::New(std::min(ulx, llx)));
+                arr->Set(1, Nan::New(std::min(lry, lly)));
+                arr->Set(2, Nan::New(std::max(urx, lrx)));
+                arr->Set(3, Nan::New(std::max(ury, uly)));
                 info.GetReturnValue().Set(arr);
-            }
-            else
-            {
+            } else {
                 Nan::ThrowError("Must provide an array of either [x,y] or [minx,miny,maxx,maxy]");
                 return;
             }
         }
-    } catch (std::exception const & ex) {
+    } catch (std::exception const& ex) {
         Nan::ThrowError(ex.what());
         return;
     }
@@ -173,12 +155,10 @@ NAN_METHOD(Projection::forward)
  * @param {Array<number>} position as [x, y] or extent as [minx,miny,maxx,maxy]
  * @returns {Array<number>} unprojected coordinates
  */
-NAN_METHOD(Projection::inverse)
-{
+NAN_METHOD(Projection::inverse) {
     Projection* p = Nan::ObjectWrap::Unwrap<Projection>(info.Holder());
 
-    try
-    {
+    try {
         if (info.Length() != 1) {
             Nan::ThrowError("Must provide an array of either [x,y] or [minx,miny,maxx,maxy]");
             return;
@@ -189,38 +169,33 @@ NAN_METHOD(Projection::inverse)
             }
             v8::Local<v8::Array> a = info[0].As<v8::Array>();
             unsigned int array_length = a->Length();
-            if (array_length == 2)
-            {
+            if (array_length == 2) {
                 double x = a->Get(0)->NumberValue();
                 double y = a->Get(1)->NumberValue();
-                p->projection_->inverse(x,y);
+                p->projection_->inverse(x, y);
                 v8::Local<v8::Array> arr = Nan::New<v8::Array>(2);
                 arr->Set(0, Nan::New(x));
                 arr->Set(1, Nan::New(y));
                 info.GetReturnValue().Set(arr);
-            }
-            else if (array_length == 4)
-            {
+            } else if (array_length == 4) {
                 double minx = a->Get(0)->NumberValue();
                 double miny = a->Get(1)->NumberValue();
                 double maxx = a->Get(2)->NumberValue();
                 double maxy = a->Get(3)->NumberValue();
-                p->projection_->inverse(minx,miny);
-                p->projection_->inverse(maxx,maxy);
+                p->projection_->inverse(minx, miny);
+                p->projection_->inverse(maxx, maxy);
                 v8::Local<v8::Array> arr = Nan::New<v8::Array>(4);
                 arr->Set(0, Nan::New(minx));
                 arr->Set(1, Nan::New(miny));
                 arr->Set(2, Nan::New(maxx));
                 arr->Set(3, Nan::New(maxy));
                 info.GetReturnValue().Set(arr);
-            }
-            else
-            {
+            } else {
                 Nan::ThrowError("Must provide an array of either [x,y] or [minx,miny,maxx,maxy]");
                 return;
             }
         }
-    } catch (std::exception const & ex) {
+    } catch (std::exception const& ex) {
         Nan::ThrowError(ex.what());
         return;
     }
@@ -244,22 +219,19 @@ void ProjTransform::Initialize(v8::Local<v8::Object> target) {
 }
 
 ProjTransform::ProjTransform(mapnik::projection const& src,
-                             mapnik::projection const& dest) :
-    Nan::ObjectWrap(),
-    this_(std::make_shared<mapnik::proj_transform>(src,dest)) {}
+                             mapnik::projection const& dest) : Nan::ObjectWrap(),
+                                                               this_(std::make_shared<mapnik::proj_transform>(src, dest)) {}
 
-ProjTransform::~ProjTransform()
-{
+ProjTransform::~ProjTransform() {
 }
 
-NAN_METHOD(ProjTransform::New)
-{
+NAN_METHOD(ProjTransform::New) {
     if (!info.IsConstructCall()) {
         Nan::ThrowError("Cannot call constructor as function, you need to use 'new' keyword");
         return;
     }
 
-    if (info.Length() != 2 || !info[0]->IsObject()  || !info[1]->IsObject()) {
+    if (info.Length() != 2 || !info[0]->IsObject() || !info[1]->IsObject()) {
         Nan::ThrowTypeError("please provide two arguments: a pair of mapnik.Projection objects");
         return;
     }
@@ -276,24 +248,20 @@ NAN_METHOD(ProjTransform::New)
         return;
     }
 
-    Projection *p1 = Nan::ObjectWrap::Unwrap<Projection>(src_obj);
-    Projection *p2 = Nan::ObjectWrap::Unwrap<Projection>(dest_obj);
+    Projection* p1 = Nan::ObjectWrap::Unwrap<Projection>(src_obj);
+    Projection* p2 = Nan::ObjectWrap::Unwrap<Projection>(dest_obj);
 
-    try
-    {
-        ProjTransform* p = new ProjTransform(*p1->get(),*p2->get());
+    try {
+        ProjTransform* p = new ProjTransform(*p1->get(), *p2->get());
         p->Wrap(info.This());
         info.GetReturnValue().Set(info.This());
-    }
-    catch (std::exception const& ex)
-    {
+    } catch (std::exception const& ex) {
         Nan::ThrowError(ex.what());
         return;
     }
 }
 
-NAN_METHOD(ProjTransform::forward)
-{
+NAN_METHOD(ProjTransform::forward) {
     ProjTransform* p = Nan::ObjectWrap::Unwrap<ProjTransform>(info.Holder());
 
     if (info.Length() != 1) {
@@ -307,33 +275,27 @@ NAN_METHOD(ProjTransform::forward)
 
         v8::Local<v8::Array> a = info[0].As<v8::Array>();
         unsigned int array_length = a->Length();
-        if (array_length == 2)
-        {
+        if (array_length == 2) {
             double x = a->Get(0)->NumberValue();
             double y = a->Get(1)->NumberValue();
             double z = 0;
-            if (!p->this_->forward(x,y,z))
-            {
+            if (!p->this_->forward(x, y, z)) {
                 std::ostringstream s;
                 s << "Failed to forward project "
                   << a->Get(0)->NumberValue() << "," << a->Get(1)->NumberValue() << " from " << p->this_->source().params() << " to " << p->this_->dest().params();
                 Nan::ThrowError(s.str().c_str());
                 return;
-
             }
             v8::Local<v8::Array> arr = Nan::New<v8::Array>(2);
             arr->Set(0, Nan::New(x));
             arr->Set(1, Nan::New(y));
             info.GetReturnValue().Set(arr);
-        }
-        else if (array_length == 4)
-        {
+        } else if (array_length == 4) {
             mapnik::box2d<double> box(a->Get(0)->NumberValue(),
                                       a->Get(1)->NumberValue(),
                                       a->Get(2)->NumberValue(),
                                       a->Get(3)->NumberValue());
-            if (!p->this_->forward(box))
-            {
+            if (!p->this_->forward(box)) {
                 std::ostringstream s;
                 s << "Failed to forward project "
                   << box << " from " << p->this_->source().params() << " to " << p->this_->dest().params();
@@ -346,38 +308,32 @@ NAN_METHOD(ProjTransform::forward)
             arr->Set(2, Nan::New(box.maxx()));
             arr->Set(3, Nan::New(box.maxy()));
             info.GetReturnValue().Set(arr);
-        }
-        else
-        {
+        } else {
             Nan::ThrowError("Must provide an array of either [x,y] or [minx,miny,maxx,maxy]");
             return;
         }
     }
 }
 
-NAN_METHOD(ProjTransform::backward)
-{
+NAN_METHOD(ProjTransform::backward) {
     ProjTransform* p = Nan::ObjectWrap::Unwrap<ProjTransform>(info.Holder());
 
     if (info.Length() != 1) {
         Nan::ThrowError("Must provide an array of either [x,y] or [minx,miny,maxx,maxy]");
         return;
     } else {
-        if (!info[0]->IsArray())
-        {
+        if (!info[0]->IsArray()) {
             Nan::ThrowTypeError("Must provide an array of either [x,y] or [minx,miny,maxx,maxy]");
             return;
         }
 
         v8::Local<v8::Array> a = info[0].As<v8::Array>();
         unsigned int array_length = a->Length();
-        if (array_length == 2)
-        {
+        if (array_length == 2) {
             double x = a->Get(0)->NumberValue();
             double y = a->Get(1)->NumberValue();
             double z = 0;
-            if (!p->this_->backward(x,y,z))
-            {
+            if (!p->this_->backward(x, y, z)) {
                 std::ostringstream s;
                 s << "Failed to back project "
                   << a->Get(0)->NumberValue() << "," << a->Get(1)->NumberValue() << " from " << p->this_->dest().params() << " to: " << p->this_->source().params();
@@ -388,15 +344,12 @@ NAN_METHOD(ProjTransform::backward)
             arr->Set(0, Nan::New(x));
             arr->Set(1, Nan::New(y));
             info.GetReturnValue().Set(arr);
-        }
-        else if (array_length == 4)
-        {
+        } else if (array_length == 4) {
             mapnik::box2d<double> box(a->Get(0)->NumberValue(),
                                       a->Get(1)->NumberValue(),
                                       a->Get(2)->NumberValue(),
                                       a->Get(3)->NumberValue());
-            if (!p->this_->backward(box))
-            {
+            if (!p->this_->backward(box)) {
                 std::ostringstream s;
                 s << "Failed to back project "
                   << box << " from " << p->this_->source().params() << " to " << p->this_->dest().params();
@@ -409,9 +362,7 @@ NAN_METHOD(ProjTransform::backward)
             arr->Set(2, Nan::New(box.maxx()));
             arr->Set(3, Nan::New(box.maxy()));
             info.GetReturnValue().Set(arr);
-        }
-        else
-        {
+        } else {
             Nan::ThrowError("Must provide an array of either [x,y] or [minx,miny,maxx,maxy]");
             return;
         }

--- a/src/mapnik_projection.hpp
+++ b/src/mapnik_projection.hpp
@@ -8,18 +8,20 @@
 #pragma GCC diagnostic pop
 
 // stl
-#include <string>
 #include <memory>
+#include <string>
 
-namespace mapnik { class proj_transform; }
-namespace mapnik { class projection; }
-
-
+namespace mapnik {
+class proj_transform;
+}
+namespace mapnik {
+class projection;
+}
 
 typedef std::shared_ptr<mapnik::projection> proj_ptr;
 
-class Projection: public Nan::ObjectWrap {
-public:
+class Projection : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -31,15 +33,15 @@ public:
 
     inline proj_ptr get() { return projection_; }
 
-private:
+  private:
     ~Projection();
     proj_ptr projection_;
 };
 
 typedef std::shared_ptr<mapnik::proj_transform> proj_tr_ptr;
 
-class ProjTransform: public Nan::ObjectWrap {
-public:
+class ProjTransform : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -55,11 +57,9 @@ public:
     void _ref() { Ref(); }
     void _unref() { Unref(); }
 
-private:
+  private:
     ~ProjTransform();
     proj_tr_ptr this_;
 };
 
-
 #endif
-

--- a/src/mapnik_vector_tile.hpp
+++ b/src/mapnik_vector_tile.hpp
@@ -11,8 +11,8 @@
 #include "vector_tile_merc_tile.hpp"
 
 // std
-#include <string>
 #include <set>
+#include <string>
 #include <vector>
 
 // mapnik
@@ -21,41 +21,35 @@
 // boost
 #include <boost/version.hpp>
 
-struct query_lonlat 
-{
+struct query_lonlat {
     double lon;
     double lat;
 };
 
-struct query_result 
-{
+struct query_result {
     std::string layer;
     double distance;
     double x_hit;
     double y_hit;
     mapnik::feature_ptr feature;
-    explicit query_result() :
-     layer(),
-     distance(0),
-     x_hit(0),
-     y_hit(0) {}
+    explicit query_result() : layer(),
+                              distance(0),
+                              x_hit(0),
+                              y_hit(0) {}
 };
 
-struct query_hit 
-{
+struct query_hit {
     double distance;
     unsigned feature_id;
 };
 
-struct queryMany_result 
-{
-    std::map<unsigned,query_result> features;
-    std::map<unsigned,std::vector<query_hit> > hits;
+struct queryMany_result {
+    std::map<unsigned, query_result> features;
+    std::map<unsigned, std::vector<query_hit>> hits;
 };
 
-class VectorTile: public Nan::ObjectWrap
-{
-public:
+class VectorTile : public Nan::ObjectWrap {
+  public:
     static Nan::Persistent<v8::FunctionTemplate> constructor;
     static void Initialize(v8::Local<v8::Object> target);
     static NAN_METHOD(New);
@@ -73,7 +67,7 @@ public:
     static bool _querySort(query_result const& a, query_result const& b);
     static v8::Local<v8::Array> _queryResultToV8(std::vector<query_result> const& result);
     static NAN_METHOD(queryMany);
-    static void _queryMany(queryMany_result & result, VectorTile* d, std::vector<query_lonlat> const& query, double tolerance, std::string const& layer_name, std::vector<std::string> const& fields);
+    static void _queryMany(queryMany_result& result, VectorTile* d, std::vector<query_lonlat> const& query, double tolerance, std::string const& layer_name, std::vector<std::string> const& fields);
     static bool _queryManySort(query_hit const& a, query_hit const& b);
     static v8::Local<v8::Object> _queryManyResultToV8(queryMany_result const& result);
     static void EIO_QueryMany(uv_work_t* req);
@@ -149,58 +143,49 @@ public:
     static NAN_GETTER(get_buffer_size);
     static NAN_SETTER(set_buffer_size);
 
-    VectorTile(std::uint64_t z, 
-               std::uint64_t x, 
-               std::uint64_t y, 
+    VectorTile(std::uint64_t z,
+               std::uint64_t x,
+               std::uint64_t y,
                std::uint32_t tile_size,
                std::int32_t buffer_size);
 
-    void clear() 
-    {
+    void clear() {
         tile_->clear();
     }
-    
-    std::uint32_t tile_size() const
-    {
+
+    std::uint32_t tile_size() const {
         return tile_->tile_size();
     }
-    
-    void tile_size(std::uint32_t val)
-    {
+
+    void tile_size(std::uint32_t val) {
         tile_->tile_size(val);
     }
-    
-    std::int32_t buffer_size() const
-    {
+
+    std::int32_t buffer_size() const {
         return tile_->buffer_size();
     }
-    
-    void buffer_size(std::int32_t val)
-    {
+
+    void buffer_size(std::int32_t val) {
         tile_->buffer_size(val);
     }
 
-    mapnik::vector_tile_impl::merc_tile_ptr & get_tile()
-    {
+    mapnik::vector_tile_impl::merc_tile_ptr& get_tile() {
         return tile_;
     }
 
-    mapnik::vector_tile_impl::merc_tile_ptr const& get_tile() const
-    {
+    mapnik::vector_tile_impl::merc_tile_ptr const& get_tile() const {
         return tile_;
     }
-    
-    void _ref()
-    { 
-        Ref(); 
-    }
-    
-    void _unref()
-    { 
-        Unref(); 
+
+    void _ref() {
+        Ref();
     }
 
-private:
+    void _unref() {
+        Unref();
+    }
+
+  private:
     mapnik::vector_tile_impl::merc_tile_ptr tile_;
     ~VectorTile();
 };

--- a/src/node_mapnik.cpp
+++ b/src/node_mapnik.cpp
@@ -2,38 +2,38 @@
 #include "vector_tile_config.hpp"
 
 // node-mapnik
-#include "mapnik_vector_tile.hpp"
-#include "mapnik_map.hpp"
+#include "mapnik_cairo_surface.hpp"
 #include "mapnik_color.hpp"
-#include "mapnik_geometry.hpp"
-#include "mapnik_logger.hpp"
-#include "mapnik_feature.hpp"
-#include "mapnik_fonts.hpp"
-#include "mapnik_plugins.hpp"
-#include "mapnik_palette.hpp"
-#include "mapnik_projection.hpp"
-#include "mapnik_layer.hpp"
 #include "mapnik_datasource.hpp"
+#include "mapnik_feature.hpp"
 #include "mapnik_featureset.hpp"
-#include "mapnik_memory_datasource.hpp"
+#include "mapnik_fonts.hpp"
+#include "mapnik_geometry.hpp"
 #include "mapnik_image.hpp"
 #include "mapnik_image_view.hpp"
-#include "mapnik_cairo_surface.hpp"
+#include "mapnik_layer.hpp"
+#include "mapnik_logger.hpp"
+#include "mapnik_map.hpp"
+#include "mapnik_memory_datasource.hpp"
+#include "mapnik_palette.hpp"
+#include "mapnik_plugins.hpp"
+#include "mapnik_projection.hpp"
+#include "mapnik_vector_tile.hpp"
 #if defined(GRID_RENDERER)
 #include "mapnik_grid.hpp"
 #include "mapnik_grid_view.hpp"
 #endif
+#include "blend.hpp"
 #include "mapnik_expression.hpp"
 #include "utils.hpp"
-#include "blend.hpp"
 
 // mapnik
 #include <mapnik/config.hpp> // for MAPNIK_DECL
-#include <mapnik/version.hpp>
-#include <mapnik/marker_cache.hpp>
-#include <mapnik/mapped_memory_cache.hpp>
 #include <mapnik/image_compositing.hpp>
 #include <mapnik/image_scaling.hpp>
+#include <mapnik/mapped_memory_cache.hpp>
+#include <mapnik/marker_cache.hpp>
+#include <mapnik/version.hpp>
 
 // boost
 #include <boost/version.hpp>
@@ -48,18 +48,13 @@
 
 namespace node_mapnik {
 
-
-
-
-static std::string format_version(int version)
-{
+static std::string format_version(int version) {
     std::ostringstream s;
-    s << version/100000 << "." << version/100 % 1000  << "." << version % 100;
+    s << version / 100000 << "." << version / 100 % 1000 << "." << version % 100;
     return s.str();
 }
 
-static NAN_METHOD(clearCache)
-{
+static NAN_METHOD(clearCache) {
     Nan::HandleScope scope;
 #if defined(MAPNIK_MEMORY_MAPPED_FILE)
     mapnik::marker_cache::instance().clear();
@@ -116,135 +111,133 @@ static NAN_METHOD(clearCache)
  */
 extern "C" {
 
-    static void InitMapnik (v8::Local<v8::Object> target)
-    {
-        Nan::HandleScope scope;
+static void InitMapnik(v8::Local<v8::Object> target) {
+    Nan::HandleScope scope;
 
-        // module level functions
-        Nan::SetMethod(target, "blend",node_mapnik::Blend);
-        Nan::SetMethod(target, "rgb2hsl", rgb2hsl);
-        Nan::SetMethod(target, "hsl2rgb", hsl2rgb);
-        // back compat
-        Nan::SetMethod(target, "registerFonts", node_mapnik::register_fonts);
-        Nan::SetMethod(target, "registerDatasource", node_mapnik::register_datasource);
-        Nan::SetMethod(target, "registerDatasources", node_mapnik::register_datasources);
-        Nan::SetMethod(target, "register_fonts", node_mapnik::register_fonts);
-        Nan::SetMethod(target, "register_datasource", node_mapnik::register_datasource);
-        Nan::SetMethod(target, "register_datasources", node_mapnik::register_datasources);
-        Nan::SetMethod(target, "datasources", node_mapnik::available_input_plugins);
-        Nan::SetMethod(target, "fonts", node_mapnik::available_font_faces);
-        Nan::SetMethod(target, "fontFiles", node_mapnik::available_font_files);
-        Nan::SetMethod(target, "memoryFonts", node_mapnik::memory_fonts);
-        Nan::SetMethod(target, "clearCache", clearCache);
+    // module level functions
+    Nan::SetMethod(target, "blend", node_mapnik::Blend);
+    Nan::SetMethod(target, "rgb2hsl", rgb2hsl);
+    Nan::SetMethod(target, "hsl2rgb", hsl2rgb);
+    // back compat
+    Nan::SetMethod(target, "registerFonts", node_mapnik::register_fonts);
+    Nan::SetMethod(target, "registerDatasource", node_mapnik::register_datasource);
+    Nan::SetMethod(target, "registerDatasources", node_mapnik::register_datasources);
+    Nan::SetMethod(target, "register_fonts", node_mapnik::register_fonts);
+    Nan::SetMethod(target, "register_datasource", node_mapnik::register_datasource);
+    Nan::SetMethod(target, "register_datasources", node_mapnik::register_datasources);
+    Nan::SetMethod(target, "datasources", node_mapnik::available_input_plugins);
+    Nan::SetMethod(target, "fonts", node_mapnik::available_font_faces);
+    Nan::SetMethod(target, "fontFiles", node_mapnik::available_font_files);
+    Nan::SetMethod(target, "memoryFonts", node_mapnik::memory_fonts);
+    Nan::SetMethod(target, "clearCache", clearCache);
 
-        // Classes
-        VectorTile::Initialize(target);
-        Map::Initialize(target);
-        Color::Initialize(target);
-        Geometry::Initialize(target);
-        Feature::Initialize(target);
-        Image::Initialize(target);
-        ImageView::Initialize(target);
-        Palette::Initialize(target);
-        Projection::Initialize(target);
-        ProjTransform::Initialize(target);
-        Layer::Initialize(target);
+    // Classes
+    VectorTile::Initialize(target);
+    Map::Initialize(target);
+    Color::Initialize(target);
+    Geometry::Initialize(target);
+    Feature::Initialize(target);
+    Image::Initialize(target);
+    ImageView::Initialize(target);
+    Palette::Initialize(target);
+    Projection::Initialize(target);
+    ProjTransform::Initialize(target);
+    Layer::Initialize(target);
 #if defined(GRID_RENDERER)
-        Grid::Initialize(target);
-        GridView::Initialize(target);
+    Grid::Initialize(target);
+    GridView::Initialize(target);
 #endif
-        Datasource::Initialize(target);
-        Featureset::Initialize(target);
-        Logger::Initialize(target);
-        // Not production safe, so disabling indefinitely
-        //JSDatasource::Initialize(target);
-        MemoryDatasource::Initialize(target);
-        Expression::Initialize(target);
-        CairoSurface::Initialize(target);
+    Datasource::Initialize(target);
+    Featureset::Initialize(target);
+    Logger::Initialize(target);
+    // Not production safe, so disabling indefinitely
+    //JSDatasource::Initialize(target);
+    MemoryDatasource::Initialize(target);
+    Expression::Initialize(target);
+    CairoSurface::Initialize(target);
 
-        // versions of deps
-        v8::Local<v8::Object> versions = Nan::New<v8::Object>();
-        versions->Set(Nan::New("node").ToLocalChecked(), Nan::New<v8::String>(NODE_VERSION+1).ToLocalChecked()); // NOTE: +1 strips the v in v0.10.26
-        versions->Set(Nan::New("v8").ToLocalChecked(), Nan::New<v8::String>(v8::V8::GetVersion()).ToLocalChecked());
-        versions->Set(Nan::New("boost").ToLocalChecked(), Nan::New<v8::String>(format_version(BOOST_VERSION)).ToLocalChecked());
-        versions->Set(Nan::New("boost_number").ToLocalChecked(), Nan::New(BOOST_VERSION));
-        versions->Set(Nan::New("mapnik").ToLocalChecked(), Nan::New<v8::String>(format_version(MAPNIK_VERSION)).ToLocalChecked());
-        versions->Set(Nan::New("mapnik_number").ToLocalChecked(), Nan::New(MAPNIK_VERSION));
-        versions->Set(Nan::New("mapnik_git_describe").ToLocalChecked(), Nan::New<v8::String>(MAPNIK_GIT_REVISION).ToLocalChecked());
+    // versions of deps
+    v8::Local<v8::Object> versions = Nan::New<v8::Object>();
+    versions->Set(Nan::New("node").ToLocalChecked(), Nan::New<v8::String>(NODE_VERSION + 1).ToLocalChecked()); // NOTE: +1 strips the v in v0.10.26
+    versions->Set(Nan::New("v8").ToLocalChecked(), Nan::New<v8::String>(v8::V8::GetVersion()).ToLocalChecked());
+    versions->Set(Nan::New("boost").ToLocalChecked(), Nan::New<v8::String>(format_version(BOOST_VERSION)).ToLocalChecked());
+    versions->Set(Nan::New("boost_number").ToLocalChecked(), Nan::New(BOOST_VERSION));
+    versions->Set(Nan::New("mapnik").ToLocalChecked(), Nan::New<v8::String>(format_version(MAPNIK_VERSION)).ToLocalChecked());
+    versions->Set(Nan::New("mapnik_number").ToLocalChecked(), Nan::New(MAPNIK_VERSION));
+    versions->Set(Nan::New("mapnik_git_describe").ToLocalChecked(), Nan::New<v8::String>(MAPNIK_GIT_REVISION).ToLocalChecked());
 #if defined(HAVE_CAIRO)
-        versions->Set(Nan::New("cairo").ToLocalChecked(), Nan::New<v8::String>(CAIRO_VERSION_STRING).ToLocalChecked());
+    versions->Set(Nan::New("cairo").ToLocalChecked(), Nan::New<v8::String>(CAIRO_VERSION_STRING).ToLocalChecked());
 #endif
-        target->Set(Nan::New("versions").ToLocalChecked(), versions);
+    target->Set(Nan::New("versions").ToLocalChecked(), versions);
 
-        v8::Local<v8::Object> supports = Nan::New<v8::Object>();
+    v8::Local<v8::Object> supports = Nan::New<v8::Object>();
 #ifdef GRID_RENDERER
-        supports->Set(Nan::New("grid").ToLocalChecked(), Nan::True());
+    supports->Set(Nan::New("grid").ToLocalChecked(), Nan::True());
 #else
-        supports->Set(Nan::New("grid").ToLocalChecked(), Nan::False());
+    supports->Set(Nan::New("grid").ToLocalChecked(), Nan::False());
 #endif
 
 #ifdef SVG_RENDERER
-        supports->Set(Nan::New("svg").ToLocalChecked(), Nan::True());
+    supports->Set(Nan::New("svg").ToLocalChecked(), Nan::True());
 #else
-        supports->Set(Nan::New("svg").ToLocalChecked(), Nan::False());
+    supports->Set(Nan::New("svg").ToLocalChecked(), Nan::False());
 #endif
 
 #if defined(HAVE_CAIRO)
-        supports->Set(Nan::New("cairo").ToLocalChecked(), Nan::True());
-        #ifdef CAIRO_HAS_PDF_SURFACE
-        supports->Set(Nan::New("cairo_pdf").ToLocalChecked(), Nan::True());
-        #else
-        supports->Set(Nan::New("cairo_pdf").ToLocalChecked(), Nan::False());
-        #endif
-        #ifdef CAIRO_HAS_SVG_SURFACE
-        supports->Set(Nan::New("cairo_svg").ToLocalChecked(), Nan::True());
-        #else
-        supports->Set(Nan::New("cairo_svg").ToLocalChecked(), Nan::False());
-        #endif
+    supports->Set(Nan::New("cairo").ToLocalChecked(), Nan::True());
+#ifdef CAIRO_HAS_PDF_SURFACE
+    supports->Set(Nan::New("cairo_pdf").ToLocalChecked(), Nan::True());
 #else
-        supports->Set(Nan::New("cairo").ToLocalChecked(), Nan::False());
+    supports->Set(Nan::New("cairo_pdf").ToLocalChecked(), Nan::False());
+#endif
+#ifdef CAIRO_HAS_SVG_SURFACE
+    supports->Set(Nan::New("cairo_svg").ToLocalChecked(), Nan::True());
+#else
+    supports->Set(Nan::New("cairo_svg").ToLocalChecked(), Nan::False());
+#endif
+#else
+    supports->Set(Nan::New("cairo").ToLocalChecked(), Nan::False());
 #endif
 
 #if defined(HAVE_PNG)
-        supports->Set(Nan::New("png").ToLocalChecked(), Nan::True());
+    supports->Set(Nan::New("png").ToLocalChecked(), Nan::True());
 #else
-        supports->Set(Nan::New("png").ToLocalChecked(), Nan::False());
+    supports->Set(Nan::New("png").ToLocalChecked(), Nan::False());
 #endif
 
 #if defined(HAVE_JPEG)
-        supports->Set(Nan::New("jpeg").ToLocalChecked(), Nan::True());
+    supports->Set(Nan::New("jpeg").ToLocalChecked(), Nan::True());
 #else
-        supports->Set(Nan::New("jpeg").ToLocalChecked(), Nan::False());
+    supports->Set(Nan::New("jpeg").ToLocalChecked(), Nan::False());
 #endif
 
 #if defined(HAVE_TIFF)
-        supports->Set(Nan::New("tiff").ToLocalChecked(), Nan::True());
+    supports->Set(Nan::New("tiff").ToLocalChecked(), Nan::True());
 #else
-        supports->Set(Nan::New("tiff").ToLocalChecked(), Nan::False());
+    supports->Set(Nan::New("tiff").ToLocalChecked(), Nan::False());
 #endif
 
 #if defined(HAVE_WEBP)
-        supports->Set(Nan::New("webp").ToLocalChecked(), Nan::True());
+    supports->Set(Nan::New("webp").ToLocalChecked(), Nan::True());
 #else
-        supports->Set(Nan::New("webp").ToLocalChecked(), Nan::False());
+    supports->Set(Nan::New("webp").ToLocalChecked(), Nan::False());
 #endif
 
 #if defined(MAPNIK_USE_PROJ4)
-        supports->Set(Nan::New("proj4").ToLocalChecked(), Nan::True());
+    supports->Set(Nan::New("proj4").ToLocalChecked(), Nan::True());
 #else
-        supports->Set(Nan::New("proj4").ToLocalChecked(), Nan::False());
+    supports->Set(Nan::New("proj4").ToLocalChecked(), Nan::False());
 #endif
 
 #if defined(MAPNIK_THREADSAFE)
-        supports->Set(Nan::New("threadsafe").ToLocalChecked(), Nan::True());
+    supports->Set(Nan::New("threadsafe").ToLocalChecked(), Nan::True());
 #else
-        supports->Set(Nan::New("threadsafe").ToLocalChecked(), Nan::False());
+    supports->Set(Nan::New("threadsafe").ToLocalChecked(), Nan::False());
 #endif
 
-        target->Set(Nan::New("supports").ToLocalChecked(), supports);
+    target->Set(Nan::New("supports").ToLocalChecked(), supports);
 
-
-/**
+    /**
  * Image type constants representing color and grayscale encodings.
  * Composite operation constants
  *
@@ -289,46 +282,46 @@ extern "C" {
  * @static
  * @class
  */
-        v8::Local<v8::Object> composite_ops = Nan::New<v8::Object>();
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "clear", mapnik::clear)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src", mapnik::src)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst", mapnik::dst)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src_over", mapnik::src_over)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst_over", mapnik::dst_over)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src_in", mapnik::src_in)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst_in", mapnik::dst_in)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src_out", mapnik::src_out)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst_out", mapnik::dst_out)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src_atop", mapnik::src_atop)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst_atop", mapnik::dst_atop)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "xor", mapnik::_xor)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "plus", mapnik::plus)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "minus", mapnik::minus)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "multiply", mapnik::multiply)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "screen", mapnik::screen)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "overlay", mapnik::overlay)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "darken", mapnik::darken)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "lighten", mapnik::lighten)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "color_dodge", mapnik::color_dodge)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "color_burn", mapnik::color_burn)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "hard_light", mapnik::hard_light)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "soft_light", mapnik::soft_light)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "difference", mapnik::difference)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "exclusion", mapnik::exclusion)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "contrast", mapnik::contrast)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "invert", mapnik::invert)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "invert-rgb", mapnik::invert_rgb)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "grain_merge", mapnik::grain_merge)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "grain_extract", mapnik::grain_extract)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "hue", mapnik::hue)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "saturation", mapnik::saturation)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "color", mapnik::_color)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "linear_dodge", mapnik::linear_dodge)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "linear_burn", mapnik::linear_burn)
-        NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "divide", mapnik::divide)
-        target->Set(Nan::New("compositeOp").ToLocalChecked(), composite_ops);
-        
-/**
+    v8::Local<v8::Object> composite_ops = Nan::New<v8::Object>();
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "clear", mapnik::clear)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src", mapnik::src)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst", mapnik::dst)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src_over", mapnik::src_over)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst_over", mapnik::dst_over)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src_in", mapnik::src_in)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst_in", mapnik::dst_in)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src_out", mapnik::src_out)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst_out", mapnik::dst_out)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "src_atop", mapnik::src_atop)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "dst_atop", mapnik::dst_atop)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "xor", mapnik::_xor)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "plus", mapnik::plus)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "minus", mapnik::minus)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "multiply", mapnik::multiply)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "screen", mapnik::screen)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "overlay", mapnik::overlay)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "darken", mapnik::darken)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "lighten", mapnik::lighten)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "color_dodge", mapnik::color_dodge)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "color_burn", mapnik::color_burn)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "hard_light", mapnik::hard_light)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "soft_light", mapnik::soft_light)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "difference", mapnik::difference)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "exclusion", mapnik::exclusion)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "contrast", mapnik::contrast)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "invert", mapnik::invert)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "invert-rgb", mapnik::invert_rgb)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "grain_merge", mapnik::grain_merge)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "grain_extract", mapnik::grain_extract)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "hue", mapnik::hue)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "saturation", mapnik::saturation)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "color", mapnik::_color)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "linear_dodge", mapnik::linear_dodge)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "linear_burn", mapnik::linear_burn)
+    NODE_MAPNIK_DEFINE_CONSTANT(composite_ops, "divide", mapnik::divide)
+    target->Set(Nan::New("compositeOp").ToLocalChecked(), composite_ops);
+
+    /**
  * Image type constants representing color and grayscale encodings.
  *
  * @name imageType
@@ -347,22 +340,22 @@ extern "C" {
  * @property {number} gray64s
  * @property {number} gray64f
  */
-        v8::Local<v8::Object> image_types = Nan::New<v8::Object>();
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "null", mapnik::image_dtype_null)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "rgba8", mapnik::image_dtype_rgba8)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray8", mapnik::image_dtype_gray8)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray8s", mapnik::image_dtype_gray8s)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray16", mapnik::image_dtype_gray16)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray16s", mapnik::image_dtype_gray16s)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray32", mapnik::image_dtype_gray32)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray32s", mapnik::image_dtype_gray32s)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray32f", mapnik::image_dtype_gray32f)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray64", mapnik::image_dtype_gray64)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray64s", mapnik::image_dtype_gray64s)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray64f", mapnik::image_dtype_gray64f)
-        target->Set(Nan::New("imageType").ToLocalChecked(), image_types);
+    v8::Local<v8::Object> image_types = Nan::New<v8::Object>();
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "null", mapnik::image_dtype_null)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "rgba8", mapnik::image_dtype_rgba8)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray8", mapnik::image_dtype_gray8)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray8s", mapnik::image_dtype_gray8s)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray16", mapnik::image_dtype_gray16)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray16s", mapnik::image_dtype_gray16s)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray32", mapnik::image_dtype_gray32)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray32s", mapnik::image_dtype_gray32s)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray32f", mapnik::image_dtype_gray32f)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray64", mapnik::image_dtype_gray64)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray64s", mapnik::image_dtype_gray64s)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_types, "gray64f", mapnik::image_dtype_gray64f)
+    target->Set(Nan::New("imageType").ToLocalChecked(), image_types);
 
-/**
+    /**
  * Image scaling type constants representing color and grayscale encodings.
  *
  * @name imageScaling
@@ -387,27 +380,27 @@ extern "C" {
  * @property {number} lanczos
  * @property {number} blackman
  */
-        v8::Local<v8::Object> image_scaling_types = Nan::New<v8::Object>();
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "near", mapnik::SCALING_NEAR)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "bilinear", mapnik::SCALING_BILINEAR)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "bicubic", mapnik::SCALING_BICUBIC)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "spline16", mapnik::SCALING_SPLINE16)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "spline36", mapnik::SCALING_SPLINE36)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "hanning", mapnik::SCALING_HANNING)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "hamming", mapnik::SCALING_HAMMING)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "hermite", mapnik::SCALING_HERMITE)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "kaiser", mapnik::SCALING_KAISER)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "quadric", mapnik::SCALING_QUADRIC)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "catrom", mapnik::SCALING_CATROM)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "gaussian", mapnik::SCALING_GAUSSIAN)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "bessel", mapnik::SCALING_BESSEL)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "mitchell", mapnik::SCALING_MITCHELL)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "sinc", mapnik::SCALING_SINC)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "lanczos", mapnik::SCALING_LANCZOS)
-        NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "blackman", mapnik::SCALING_BLACKMAN)
-        target->Set(Nan::New("imageScaling").ToLocalChecked(), image_scaling_types);
+    v8::Local<v8::Object> image_scaling_types = Nan::New<v8::Object>();
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "near", mapnik::SCALING_NEAR)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "bilinear", mapnik::SCALING_BILINEAR)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "bicubic", mapnik::SCALING_BICUBIC)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "spline16", mapnik::SCALING_SPLINE16)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "spline36", mapnik::SCALING_SPLINE36)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "hanning", mapnik::SCALING_HANNING)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "hamming", mapnik::SCALING_HAMMING)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "hermite", mapnik::SCALING_HERMITE)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "kaiser", mapnik::SCALING_KAISER)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "quadric", mapnik::SCALING_QUADRIC)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "catrom", mapnik::SCALING_CATROM)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "gaussian", mapnik::SCALING_GAUSSIAN)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "bessel", mapnik::SCALING_BESSEL)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "mitchell", mapnik::SCALING_MITCHELL)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "sinc", mapnik::SCALING_SINC)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "lanczos", mapnik::SCALING_LANCZOS)
+    NODE_MAPNIK_DEFINE_CONSTANT(image_scaling_types, "blackman", mapnik::SCALING_BLACKMAN)
+    target->Set(Nan::New("imageScaling").ToLocalChecked(), image_scaling_types);
 
-/**
+    /**
  * Constants representing fill types understood by [Clipper during vector tile encoding](http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Types/PolyFillType.htm).
  *
  * @name polygonFillType
@@ -419,14 +412,14 @@ extern "C" {
  * @property {number} positive
  * @property {number} negative
  */
-        v8::Local<v8::Object> polygon_fill_types = Nan::New<v8::Object>();
-        NODE_MAPNIK_DEFINE_CONSTANT(polygon_fill_types, "evenOdd", mapnik::vector_tile_impl::even_odd_fill)
-        NODE_MAPNIK_DEFINE_CONSTANT(polygon_fill_types, "nonZero", mapnik::vector_tile_impl::non_zero_fill)
-        NODE_MAPNIK_DEFINE_CONSTANT(polygon_fill_types, "positive", mapnik::vector_tile_impl::positive_fill)
-        NODE_MAPNIK_DEFINE_CONSTANT(polygon_fill_types, "negative", mapnik::vector_tile_impl::negative_fill)
-        target->Set(Nan::New("polygonFillType").ToLocalChecked(), polygon_fill_types);
+    v8::Local<v8::Object> polygon_fill_types = Nan::New<v8::Object>();
+    NODE_MAPNIK_DEFINE_CONSTANT(polygon_fill_types, "evenOdd", mapnik::vector_tile_impl::even_odd_fill)
+    NODE_MAPNIK_DEFINE_CONSTANT(polygon_fill_types, "nonZero", mapnik::vector_tile_impl::non_zero_fill)
+    NODE_MAPNIK_DEFINE_CONSTANT(polygon_fill_types, "positive", mapnik::vector_tile_impl::positive_fill)
+    NODE_MAPNIK_DEFINE_CONSTANT(polygon_fill_types, "negative", mapnik::vector_tile_impl::negative_fill)
+    target->Set(Nan::New("polygonFillType").ToLocalChecked(), polygon_fill_types);
 
-/**
+    /**
  * Constants representing `std::async` threading mode (aka [launch policy](http://en.cppreference.com/w/cpp/thread/launch)).
  *
  * @name threadingMode
@@ -436,13 +429,12 @@ extern "C" {
  * @property {number} async
  * @property {number} deferred
  */
-        v8::Local<v8::Object> threading_mode = Nan::New<v8::Object>();
-        NODE_MAPNIK_DEFINE_CONSTANT(threading_mode, "async", static_cast<unsigned>(std::launch::async))
-        NODE_MAPNIK_DEFINE_CONSTANT(threading_mode, "deferred", static_cast<unsigned>(std::launch::deferred))
-        NODE_MAPNIK_DEFINE_CONSTANT(threading_mode, "auto", static_cast<unsigned>(std::launch::async | std::launch::deferred))
-        target->Set(Nan::New("threadingMode").ToLocalChecked(), threading_mode);
-
-    }
+    v8::Local<v8::Object> threading_mode = Nan::New<v8::Object>();
+    NODE_MAPNIK_DEFINE_CONSTANT(threading_mode, "async", static_cast<unsigned>(std::launch::async))
+    NODE_MAPNIK_DEFINE_CONSTANT(threading_mode, "deferred", static_cast<unsigned>(std::launch::deferred))
+    NODE_MAPNIK_DEFINE_CONSTANT(threading_mode, "auto", static_cast<unsigned>(std::launch::async | std::launch::deferred))
+    target->Set(Nan::New("threadingMode").ToLocalChecked(), threading_mode);
+}
 }
 
 } // namespace node_mapnik
@@ -451,27 +443,25 @@ extern "C" {
 // https://github.com/joyent/node/commit/bd8a5755dceda415eee147bc06574f5a30abb0d0#commitcomment-5686345
 #if NODE_VERSION_AT_LEAST(0, 9, 0)
 
-#define NODE_MAPNIK_MODULE(modname, regfunc)                          \
-  extern "C" {                                                        \
-    MAPNIK_EXP node::node_module_struct modname ## _module =          \
-    {                                                                 \
-      NODE_STANDARD_MODULE_STUFF,                                     \
-      (node::addon_register_func)regfunc,                             \
-      NODE_STRINGIFY(modname)                                         \
-    };                                                                \
-  }
+#define NODE_MAPNIK_MODULE(modname, regfunc)               \
+    extern "C" {                                           \
+    MAPNIK_EXP node::node_module_struct modname##_module = \
+        {                                                  \
+            NODE_STANDARD_MODULE_STUFF,                    \
+            (node::addon_register_func)regfunc,            \
+            NODE_STRINGIFY(modname)};                      \
+    }
 
 #else
 
-#define NODE_MAPNIK_MODULE(modname, regfunc)                          \
-  extern "C" {                                                        \
-    MAPNIK_EXP node::node_module_struct modname ## _module =          \
-    {                                                                 \
-      NODE_STANDARD_MODULE_STUFF,                                     \
-      regfunc,                                                        \
-      NODE_STRINGIFY(modname)                                         \
-    };                                                                \
-  }
+#define NODE_MAPNIK_MODULE(modname, regfunc)               \
+    extern "C" {                                           \
+    MAPNIK_EXP node::node_module_struct modname##_module = \
+        {                                                  \
+            NODE_STANDARD_MODULE_STUFF,                    \
+            regfunc,                                       \
+            NODE_STRINGIFY(modname)};                      \
+    }
 
 #endif
 

--- a/src/object_to_container.hpp
+++ b/src/object_to_container.hpp
@@ -1,18 +1,18 @@
 #ifndef __NODE_MAPNIK_OBJECT_TO_CONTAINER__
 #define __NODE_MAPNIK_OBJECT_TO_CONTAINER__
 
-#include <mapnik/version.hpp>
+#include "utils.hpp"
 #include <mapnik/attribute.hpp>
 #include <mapnik/unicode.hpp>
 #include <mapnik/value_types.hpp>
+#include <mapnik/version.hpp>
 
-static inline void object_to_container(mapnik::attributes & cont, v8::Local<v8::Object> const& vars)
-{
+static inline void object_to_container(mapnik::attributes& cont, v8::Local<v8::Object> const& vars) {
     v8::Local<v8::Array> names = vars->GetPropertyNames();
     std::size_t a_length = names->Length();
     mapnik::transcoder tr("utf8");
     cont.reserve(a_length);
-    for(std::size_t i=0; i < a_length; ++i) {
+    for (std::size_t i = 0; i < a_length; ++i) {
         v8::Local<v8::Value> name = names->Get(i)->ToString();
         v8::Local<v8::Value> value = vars->Get(name);
         if (value->IsBoolean()) {

--- a/src/tint.hpp
+++ b/src/tint.hpp
@@ -5,12 +5,12 @@
 #include <string>
 
 static inline void rgb_to_hsl(unsigned red, unsigned green, unsigned blue,
-             double & h, double & s, double & l) {
-    double r = red/255.0;
-    double g = green/255.0;
-    double b = blue/255.0;
-    double max = std::max(r,std::max(g,b));
-    double min = std::min(r,std::min(g,b));
+                              double& h, double& s, double& l) {
+    double r = red / 255.0;
+    double g = green / 255.0;
+    double b = blue / 255.0;
+    double max = std::max(r, std::max(g, b));
+    double min = std::min(r, std::min(g, b));
     double delta = max - min;
     double gamma = max + min;
     h = 0.0, s = 0.0, l = gamma / 2.0;
@@ -25,8 +25,8 @@ static inline void rgb_to_hsl(unsigned red, unsigned green, unsigned blue,
 
 static inline double hueToRGB(double m1, double m2, double h) {
     // poor mans fmod
-    if(h < 0) h += 1;
-    if(h > 1) h -= 1;
+    if (h < 0) h += 1;
+    if (h > 1) h -= 1;
     if (h * 6 < 1) return m1 + (m2 - m1) * h * 6;
     if (h * 2 < 1) return m2;
     if (h * 3 < 2) return m1 + (m2 - m1) * (0.66666 - h) * 6;
@@ -34,20 +34,17 @@ static inline double hueToRGB(double m1, double m2, double h) {
 }
 
 static inline void hsl_to_rgb(double h, double s, double l,
-             unsigned & r, unsigned & g, unsigned & b) {
+                              unsigned& r, unsigned& g, unsigned& b) {
     if (!s) {
-        r = g = b = static_cast<unsigned>(std::floor((l * 255.0)+.5));
-    }
-    else
-    {
+        r = g = b = static_cast<unsigned>(std::floor((l * 255.0) + .5));
+    } else {
         double m2 = (l <= 0.5) ? l * (s + 1) : l + s - l * s;
         double m1 = l * 2.0 - m2;
-        r = static_cast<unsigned>(std::floor(hueToRGB(m1, m2, h + 0.33333) * 255.0)+.5);
-        g = static_cast<unsigned>(std::floor(hueToRGB(m1, m2, h) * 255.0)+.5);
-        b = static_cast<unsigned>(std::floor(hueToRGB(m1, m2, h - 0.33333) * 255.0)+.5);
+        r = static_cast<unsigned>(std::floor(hueToRGB(m1, m2, h + 0.33333) * 255.0) + .5);
+        g = static_cast<unsigned>(std::floor(hueToRGB(m1, m2, h) * 255.0) + .5);
+        b = static_cast<unsigned>(std::floor(hueToRGB(m1, m2, h - 0.33333) * 255.0) + .5);
     }
 }
-
 
 struct Tinter {
     double h0;
@@ -59,15 +56,14 @@ struct Tinter {
     double a0;
     double a1;
 
-    Tinter() :
-      h0(0),
-      h1(1),
-      s0(0),
-      s1(1),
-      l0(0),
-      l1(1),
-      a0(0),
-      a1(1) {}
+    Tinter() : h0(0),
+               h1(1),
+               s0(0),
+               s1(1),
+               l0(0),
+               l1(1),
+               a0(0),
+               a1(1) {}
 
     bool is_identity() const {
         return (h0 == 0 &&
@@ -83,6 +79,5 @@ struct Tinter {
                 a1 == 1);
     }
 };
-
 
 #endif

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -8,83 +8,72 @@
 #pragma GCC diagnostic pop
 
 // stl
-#include <string>
 #include <memory>
+#include <string>
 
 // core types
-#include <mapnik/unicode.hpp>
-#include <mapnik/value_types.hpp>
-#include <mapnik/value.hpp>
-#include <mapnik/version.hpp>
 #include <mapnik/params.hpp>
+#include <mapnik/unicode.hpp>
+#include <mapnik/value.hpp>
+#include <mapnik/value_types.hpp>
+#include <mapnik/version.hpp>
 
 #define TOSTR(obj) (*v8::String::Utf8Value((obj)->ToString()))
 
-#define FUNCTION_ARG(I, VAR)                                            \
-    if (info.Length() <= (I) || !info[I]->IsFunction()) {               \
-        Nan::ThrowTypeError("Argument " #I " must be a function");      \
-        return;                                                         \
-    }                                                                   \
+#define FUNCTION_ARG(I, VAR)                                       \
+    if (info.Length() <= (I) || !info[I]->IsFunction()) {          \
+        Nan::ThrowTypeError("Argument " #I " must be a function"); \
+        return;                                                    \
+    }                                                              \
     v8::Local<v8::Function> VAR = info[I].As<v8::Function>();
 
-#define ATTR(t, name, get, set)                                         \
+#define ATTR(t, name, get, set) \
     Nan::SetAccessor(t->InstanceTemplate(), Nan::New<v8::String>(name).ToLocalChecked(), get, set);
 
-#define NODE_MAPNIK_DEFINE_CONSTANT(target, name, constant)             \
-    (target)->Set(Nan::New<v8::String>(name).ToLocalChecked(),              \
-                  Nan::New<v8::Integer>(constant));                         \
+#define NODE_MAPNIK_DEFINE_CONSTANT(target, name, constant)    \
+    (target)->Set(Nan::New<v8::String>(name).ToLocalChecked(), \
+                  Nan::New<v8::Integer>(constant));
 
-#define NODE_MAPNIK_DEFINE_64_BIT_CONSTANT(target, name, constant)      \
-    (target)->Set(Nan::New<v8::String>(name).ToLocalChecked(),              \
-                  Nan::New<v8::Number>(constant));                          \
-
-
-
+#define NODE_MAPNIK_DEFINE_64_BIT_CONSTANT(target, name, constant) \
+    (target)->Set(Nan::New<v8::String>(name).ToLocalChecked(),     \
+                  Nan::New<v8::Number>(constant));
 
 namespace node_mapnik {
 
 typedef mapnik::value_integer value_integer;
 
 // adapted to work for both mapnik features and mapnik parameters
-struct value_converter
-{
-    v8::Local<v8::Value> operator () ( value_integer val ) const
-    {
+struct value_converter {
+    v8::Local<v8::Value> operator()(value_integer val) const {
         return Nan::New<v8::Number>(val);
     }
 
-    v8::Local<v8::Value> operator () (mapnik::value_bool val ) const
-    {
+    v8::Local<v8::Value> operator()(mapnik::value_bool val) const {
         return Nan::New<v8::Boolean>(val);
     }
 
-    v8::Local<v8::Value> operator () ( double val ) const
-    {
+    v8::Local<v8::Value> operator()(double val) const {
         return Nan::New<v8::Number>(val);
     }
 
-    v8::Local<v8::Value> operator () ( std::string const& val ) const
-    {
+    v8::Local<v8::Value> operator()(std::string const& val) const {
         return Nan::New<v8::String>(val.c_str()).ToLocalChecked();
     }
 
-    v8::Local<v8::Value> operator () ( mapnik::value_unicode_string const& val) const
-    {
+    v8::Local<v8::Value> operator()(mapnik::value_unicode_string const& val) const {
         std::string buffer;
-        mapnik::to_utf8(val,buffer);
+        mapnik::to_utf8(val, buffer);
         return Nan::New<v8::String>(buffer.c_str()).ToLocalChecked();
     }
 
-    v8::Local<v8::Value> operator () ( mapnik::value_null const& ) const
-    {
+    v8::Local<v8::Value> operator()(mapnik::value_null const&) const {
         return Nan::Null();
     }
 };
 
-inline void params_to_object(v8::Local<v8::Object>& ds, std::string const& key, mapnik::value_holder const& val)
-{
+inline void params_to_object(v8::Local<v8::Object>& ds, std::string const& key, mapnik::value_holder const& val) {
     ds->Set(Nan::New<v8::String>(key.c_str()).ToLocalChecked(), mapnik::util::apply_visitor(value_converter(), val));
 }
 
-} // end ns
+} // namespace node_mapnik
 #endif


### PR DESCRIPTION
Addresses #807 for the v3.0.x branch. Selected parts will need to be ported to master after this is confirmed to be working on travis.