### PR TITLE
[v3.0.x] Node 10 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,10 @@ matrix:
     - os: linux
       env: BUILDTYPE=release
       node_js: 9
+    # linux publishable node v10
+    - os: linux
+      env: BUILDTYPE=release
+      node_js: 10
     # osx publishable node v0.10
     - os: osx
       osx_image: xcode8.3
@@ -118,6 +122,11 @@ matrix:
       osx_image: xcode8.3
       env: BUILDTYPE=release
       node_js: 9
+    # osx publishable node v10
+    - os: osx
+      osx_image: xcode8.2
+      env: BUILDTYPE=release
+      node_js: 10
     # Sanitizer build linux node v4/Debug
     - os: linux
       env: BUILDTYPE=debug TOOLSET=-asan

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "dependencies": {
     "mapnik-vector-tile": "1.6.1",
     "protozero": "1.5.1",
-    "nan": "~2.8.0",
-    "node-pre-gyp": "~0.6.30"
+    "nan": "~2.10.0",
+    "node-pre-gyp": "~0.10.0"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -3220,7 +3220,9 @@ void Image::EIO_AfterFromSVGBytes(uv_work_t* req)
     {
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
-        v8::Local<v8::Object> image_obj = Nan::New(constructor)->GetFunction()->NewInstance(1, &ext);
+        Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
+        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
+        v8::Local<v8::Object> image_obj = maybe_local.ToLocalChecked()->ToObject();
         v8::Local<v8::Value> argv[2] = { Nan::Null(), image_obj };
         Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
     }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -18,7 +18,7 @@
 #include <mapnik/version.hpp>
 #include <mapnik/params.hpp>
 
-#define TOSTR(obj) (*v8::String::Utf8Value((obj)->ToString()))
+#define TOSTR(obj) (*Nan::Utf8String(obj))
 
 #define FUNCTION_ARG(I, VAR)                                            \
     if (info.Length() <= (I) || !info[I]->IsFunction()) {               \

--- a/test/vector-tile.test.js
+++ b/test/vector-tile.test.js
@@ -797,59 +797,59 @@ describe('mapnik.VectorTile ', function() {
         var data = fs.readFileSync("./test/data/vector_tile/tile1.vector.pbf");
         vtile.setData(data);
         assert.throws(
-            function() { vtile.getDataSync(null); }, 
+            function() { vtile.getDataSync(null); }, null,
             "first arg must be a options object"
         );
         assert.throws(
-            function() { vtile.getData(null, function(err, out) {}); }, 
+            function() { vtile.getData(null, function(err, out) {}); }, null,
             "first arg must be a options object"
         );
         assert.throws(
-            function() { vtile.getDataSync({compression:null}); }, 
+            function() { vtile.getDataSync({compression:null}); }, null,
             "option 'compression' must be a string, either 'gzip', or 'none' (default)"
         );
         assert.throws(
-            function() { vtile.getData({compression:null}, function(err,out) {}); }, 
+            function() { vtile.getData({compression:null}, function(err,out) {}); }, null,
             "option 'compression' must be a string, either 'gzip', or 'none' (default)"
         );
         assert.throws(
-            function() { vtile.getDataSync({level:null}); }, 
+            function() { vtile.getDataSync({level:null}); }, null,
             "option 'level' must be an integer between 0 (no compression) and 9 (best compression) inclusive"
         );
         assert.throws(
-            function() { vtile.getData({level:null}, function(err,out) {}); }, 
+            function() { vtile.getData({level:null}, function(err,out) {}); }, null,
             "option 'level' must be an integer between 0 (no compression) and 9 (best compression) inclusive"
         );
         assert.throws(
-            function() { vtile.getDataSync({level:99}); }, 
+            function() { vtile.getDataSync({level:99}); }, null,
             "option 'level' must be an integer between 0 (no compression) and 9 (best compression) inclusive"
         );
         assert.throws(
-            function() { vtile.getData({level:99}, function(err,out) {}); }, 
+            function() { vtile.getData({level:99}, function(err,out) {}); }, null,
             "option 'level' must be an integer between 0 (no compression) and 9 (best compression) inclusive"
         );
         assert.throws(
-            function() { vtile.getDataSync({level:-1}); }, 
+            function() { vtile.getDataSync({level:-1}); }, null,
             "option 'level' must be an integer between 0 (no compression) and 9 (best compression) inclusive"
         );
         assert.throws(
-            function() { vtile.getData({level:-1}, function(err,out) {}); }, 
+            function() { vtile.getData({level:-1}, function(err,out) {}); }, null,
             "option 'level' must be an integer between 0 (no compression) and 9 (best compression) inclusive"
         );
         assert.throws(
-            function() { vtile.getDataSync({strategy:null}); }, 
+            function() { vtile.getDataSync({strategy:null}); }, null,
             "option 'strategy' must be one of the following strings: FILTERED, HUFFMAN_ONLY, RLE, FIXED, DEFAULT"
         );
         assert.throws(
-            function() { vtile.getData({strategy:null}, function(err,out) {}); }, 
+            function() { vtile.getData({strategy:null}, function(err,out) {}); }, null,
             "option 'strategy' must be one of the following strings: FILTERED, HUFFMAN_ONLY, RLE, FIXED, DEFAULT"
         );
         assert.throws(
-            function() { vtile.getDataSync({strategy:'FOO'}); }, 
+            function() { vtile.getDataSync({strategy:'FOO'}); }, null,
             "option 'strategy' must be one of the following strings: FILTERED, HUFFMAN_ONLY, RLE, FIXED, DEFAULT"
         );
         assert.throws(
-            function() { vtile.getData({strategy:'FOO'}, function(err,out) {}); }, 
+            function() { vtile.getData({strategy:'FOO'}, function(err,out) {}); }, null,
             "option 'strategy' must be one of the following strings: FILTERED, HUFFMAN_ONLY, RLE, FIXED, DEFAULT"
         );
     });


### PR DESCRIPTION
General improvements for node 10. Feel free to just cherry-pick individual commits if you are not happy with the changes.

Required:
- 8b85751 Use Nan::NewInstance instead of `->NewInstance`. If was already done, but there was a missed call.
- 1b73465 due to a change in how assert.throws works.

Nice to have:
- 002521f Use Nan::Utf8String instead of v8::String::Utf8Value.
- 74f8f0b Add Node 10 to the build matrix

General maintenance:
- 871e126 Update nan and node-pre-gyp deps
