### PR TITLE
Move/Release semantics for VT getData

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "mapnik-vector-tile": "https://github.com/mapbox/mapnik-vector-tile/tarball/release_buffer",
+    "mapnik-vector-tile": "2.2.0",
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "mapnik-vector-tile": "2.1.1",
+    "mapnik-vector-tile": "https://github.com/mapbox/mapnik-vector-tile/tarball/release_buffer",
     "nan": "~2.10.0",
     "node-pre-gyp": "~0.10.0"
   },

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -4418,8 +4418,10 @@ v8::Local<v8::Value> VectorTile::_getDataSync(Nan::NAN_METHOD_ARGS_TYPE info)
                 if (release)
                 {
                     std::unique_ptr<std::string> out = d->tile_->release_buffer();
-                    return scope.Escape(Nan::NewBuffer(&((*out)[0]),
-                                                       out->size(),
+                    char * data = &((*out)[0]);
+                    std::size_t size = out->size();
+                    return scope.Escape(Nan::NewBuffer(data,
+                                                       size,
                                                        [](char*, void* hint) {
                                                            delete reinterpret_cast<std::string*>(hint);
                                                        },
@@ -4440,8 +4442,10 @@ v8::Local<v8::Value> VectorTile::_getDataSync(Nan::NAN_METHOD_ARGS_TYPE info)
                     // To keep the same behaviour as a non compression release, we want to clear the VT buffer
                     d->tile_->clear();
                 }
-                return scope.Escape(Nan::NewBuffer(&((*compressed)[0]),
-                                                   compressed->size(),
+                char * data = &((*compressed)[0]);
+                std::size_t size = compressed->size();
+                return scope.Escape(Nan::NewBuffer(data,
+                                                   size,
                                                    [](char*, void* hint) {
                                                        delete reinterpret_cast<std::string*>(hint);
                                                    },
@@ -4650,9 +4654,11 @@ void VectorTile::after_get_data(uv_work_t* req)
     }
     else if (!closure->data->empty())
     {
+        char * data = &((*(closure->data))[0]);
+        std::size_t size = closure->data->size();
         v8::Local<v8::Value> argv[2] = { Nan::Null(), 
-                                         Nan::NewBuffer(&((*(closure->data))[0]),
-                                                   closure->data->size(),
+                                         Nan::NewBuffer(data,
+                                                   size,
                                                    [](char*, void* hint) {
                                                        delete reinterpret_cast<std::string*>(hint);
                                                    },
@@ -4689,9 +4695,11 @@ void VectorTile::after_get_data(uv_work_t* req)
             if (closure->release)
             {
                 std::unique_ptr<std::string> out = closure->d->tile_->release_buffer();
+                char * data = &((*out)[0]);
+                std::size_t size = out->size();
                 v8::Local<v8::Value> argv[2] = { Nan::Null(), 
-                                                 Nan::NewBuffer(&((*out)[0]),
-                                                           out->size(),
+                                                 Nan::NewBuffer(data,
+                                                           size,
                                                            [](char*, void* hint) {
                                                                delete reinterpret_cast<std::string*>(hint);
                                                            },

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -4425,7 +4425,6 @@ v8::Local<v8::Value> VectorTile::_getDataSync(Nan::NAN_METHOD_ARGS_TYPE info)
                                                        },
                                                        out.release())
                                        .ToLocalChecked());
-                    return scope.Escape(Nan::CopyBuffer((char*)d->tile_->data(),raw_size).ToLocalChecked());
                 }
                 else
                 {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -86,7 +86,7 @@ inline void params_to_object(v8::Local<v8::Object>& ds, std::string const& key, 
     ds->Set(Nan::New<v8::String>(key.c_str()).ToLocalChecked(), mapnik::util::apply_visitor(value_converter(), val));
 }
 
-Nan::MaybeLocal<v8::Object> NewBufferFrom(std::unique_ptr<std::string> && ptr)
+inline Nan::MaybeLocal<v8::Object> NewBufferFrom(std::unique_ptr<std::string> && ptr)
 {
     Nan::MaybeLocal<v8::Object> res = Nan::NewBuffer(
             &(*ptr)[0],

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -86,5 +86,21 @@ inline void params_to_object(v8::Local<v8::Object>& ds, std::string const& key, 
     ds->Set(Nan::New<v8::String>(key.c_str()).ToLocalChecked(), mapnik::util::apply_visitor(value_converter(), val));
 }
 
+Nan::MaybeLocal<v8::Object> NewBufferFrom(std::unique_ptr<std::string> && ptr)
+{
+    Nan::MaybeLocal<v8::Object> res = Nan::NewBuffer(
+            &(*ptr)[0],
+            ptr->size(),
+            [](char*, void* hint) {
+                delete static_cast<std::string*>(hint);
+            },
+            ptr.get());
+    if (!res.IsEmpty())
+    {
+        ptr.release();
+    }
+    return res;
+}
+
 } // end ns
 #endif

--- a/test/vector-tile.test.js
+++ b/test/vector-tile.test.js
@@ -813,6 +813,14 @@ describe('mapnik.VectorTile ', function() {
             "option 'compression' must be a string, either 'gzip', or 'none' (default)"
         );
         assert.throws(
+            function() { vtile.getDataSync({release:null}); }, null,
+            "option 'release' must be a boolean"
+        );
+        assert.throws(
+            function() { vtile.getData({release:null}, function(err,out) {}); }, null,
+            "option 'release' must be a boolean"
+        );
+        assert.throws(
             function() { vtile.getDataSync({level:null}); }, null,
             "option 'level' must be an integer between 0 (no compression) and 9 (best compression) inclusive"
         );
@@ -1216,6 +1224,46 @@ describe('mapnik.VectorTile ', function() {
 
         gzip.write(uncompressed);
         gzip.end();
+    });
+
+    it('should be able to getData with release', function(done) {
+        var vtile1 = new mapnik.VectorTile(9,112,195);
+        var vtile2 = new mapnik.VectorTile(9,112,195);
+        var data = fs.readFileSync("./test/data/vector_tile/tile1.vector.pbf");
+        vtile1.setData(data);
+        vtile2.setData(data);
+        assert.equal(vtile1.empty(), false);
+        assert.equal(data, vtile1.getData().toString());
+        var data1 = vtile1.getData({release:true}).toString();
+        assert.equal(data, data1);
+        assert.equal(vtile1.empty(), true);
+        assert.equal(vtile2.empty(), false);
+        vtile2.getData({release:true}, function(err, buffer) {
+            if (err) throw err;
+            assert.equal(data, buffer.toString());
+            assert.equal(vtile2.empty(), true);
+            done();
+        });
+    });
+    
+    it('should be able to getData with release and compression', function(done) {
+        var vtile1 = new mapnik.VectorTile(9,112,195);
+        var vtile2 = new mapnik.VectorTile(9,112,195);
+        var data = fs.readFileSync("./test/data/vector_tile/tile1.vector.pbf");
+        vtile1.setData(data);
+        vtile2.setData(data);
+        assert.equal(vtile1.empty(), false);
+        var data_c = vtile1.getData({compression:'gzip'}).toString();
+        var data1 = vtile1.getData({release:true, compression:'gzip'}).toString();
+        assert.equal(data_c, data1);
+        assert.equal(vtile1.empty(), true);
+        assert.equal(vtile2.empty(), false);
+        vtile2.getData({release:true, compression:'gzip'}, function(err, buffer) {
+            if (err) throw err;
+            assert.equal(data_c, buffer.toString());
+            assert.equal(vtile2.empty(), true);
+            done();
+        });
     });
 
     it('should be able to setData/parse gzip compressed (sync)', function(done) {


### PR DESCRIPTION
Added the ability to release the buffer in a VT so that an additional copy is not performed in memory.

Adds the `release` option to the `VectorTile.getData()` method which will take ownership of the buffer from the VectorTile object resulting in it being empty after it is run.

Addresses #881 