### PR TITLE
Made it so that resize can now accept non premultiplied rgba8 images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.0
+- `mapnik.Image.resize` will now accept non premultiplied images and return them back as non premultiplied images
+
 ## 4.1.0
 - Added `offset_width` and `offset_height` optional parameters to the `mapnik.Image.resize` and `mapnik.Image.resizeSync` methods.
 - Made `mapink.blend()` now accept `mapnik.Image` objects. 

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -1958,7 +1958,7 @@ NAN_METHOD(Image::resize)
 struct resize_visitor
 {
 
-    resize_visitor(mapnik::image_any const& im1,
+    resize_visitor(mapnik::image_any & im1,
                    mapnik::scaling_method_e scaling_method,
                    double image_ratio_x,
                    double image_ratio_y,
@@ -1975,9 +1975,11 @@ struct resize_visitor
 
     void operator()(mapnik::image_rgba8 & im2) const
     {
+        bool remultiply = false;
         if (!im1_.get_premultiplied())
         {
-            throw std::runtime_error("RGBA8 images must be premultiplied prior to using resize");
+            remultiply = true;
+            mapnik::premultiply_alpha(im1_);
         }
         mapnik::scale_image_agg(im2,
                                 mapnik::util::get<mapnik::image_rgba8>(im1_),
@@ -1987,6 +1989,9 @@ struct resize_visitor
                                 offset_x_,
                                 offset_y_,
                                 filter_factor_);
+        if (remultiply) {
+            mapnik::demultiply_alpha(im2);
+        }
     }
 
     template <typename T>
@@ -2047,7 +2052,7 @@ struct resize_visitor
 
 
   private:
-    mapnik::image_any const & im1_;
+    mapnik::image_any & im1_;
     mapnik::scaling_method_e scaling_method_;
     double image_ratio_x_;
     double image_ratio_y_;

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -892,10 +892,24 @@ describe('mapnik.Image ', function() {
         assert.throws(function() { var im2 = im.resizeSync(4,4); });
     });
     
-    it('should fail to resize resize - not premultiplied rgba8', function(done) {
+    it('should resize - not premultiplied rgba8', function(done) {
         var im = new mapnik.Image.open('test/data/images/sat_image.png');
+        assert(!im.premultiplied());
         im.resize(100,100, {scaling_method:mapnik.imageScaling.near, filter_factor:1.0}, function(err, result) {
-            assert.throws(function() { if (err) throw err; });
+            if (err) throw err;
+            assert(!result.premultiplied());
+            done();
+        });
+    });
+
+    it('should resize - premultiplied rgba8', function(done) {
+        var im = new mapnik.Image.open('test/data/images/sat_image.png');
+        assert(!im.premultiplied());
+        im.premultiply();
+        assert(im.premultiplied());
+        im.resize(100,100, {scaling_method:mapnik.imageScaling.near, filter_factor:1.0}, function(err, result) {
+            if (err) throw err;
+            assert(result.premultiplied());
             done();
         });
     });


### PR DESCRIPTION
Made it so that non premultiplied rgba8 images can now be passed to `mapnik.Image.resize`, if the rgba8 image is non premultiplied, a non premultiplied rgba8 image is then returned from resize. Otherwise a premultiplied image is returned. 