### PR TITLE
Optimize Image Encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.1
+- Performance improvement in `mapnik.blend` and `mapnik.Image` methods by having it hold the event loop less time and copying less data into buffers
+
 ## 4.2.0
 - `mapnik.Image.resize` will now accept non premultiplied images and return them back as non premultiplied images
 

--- a/src/blend.hpp
+++ b/src/blend.hpp
@@ -8,7 +8,6 @@
 #pragma GCC diagnostic pop
 
 // stl
-#include <sstream>
 #include <string>
 #include <vector>
 #include <memory>
@@ -76,7 +75,7 @@ struct BlendBaton {
     unsigned int matte;
     int compression;
     AlphaMode mode;
-    std::ostringstream stream;
+    std::unique_ptr<std::string> output_data;
 
     BlendBaton() :
         quality(0),
@@ -87,7 +86,7 @@ struct BlendBaton {
         matte(0),
         compression(-1),
         mode(BLEND_MODE_HEXTREE),
-        stream(std::ios::out | std::ios::binary)
+        output_data()
     {
         this->request.data = this;
     }


### PR DESCRIPTION
Reduced the amount of copying that took place in blend and in some other image encoding operations. This should help reduce the amount of possible time that these operations could hold the event loop. 