### PR TITLE
Address resource leaks

### DIFF
--- a/src/blend.cpp
+++ b/src/blend.cpp
@@ -448,7 +448,7 @@ void Work_AfterBlend(uv_work_t* req) {
 
     for (auto im : baton->images) {
         if (im->im_obj) {
-            im->im_obj->_unref();
+            im->im_obj->Unref();
         }
     }
 
@@ -710,7 +710,7 @@ NAN_METHOD(Blend) {
 
     for (auto im : baton->images) {
         if (im->im_obj) {
-            im->im_obj->_ref();
+            im->im_obj->Ref();
         }
     }
 

--- a/src/mapnik_cairo_surface.hpp
+++ b/src/mapnik_cairo_surface.hpp
@@ -28,8 +28,10 @@ public:
     static NAN_METHOD(getData);
     static NAN_METHOD(width);
     static NAN_METHOD(height);
-    void _ref() { Ref(); }
-    void _unref() { Unref(); }
+
+    using Nan::ObjectWrap::Ref;
+    using Nan::ObjectWrap::Unref;
+
     CairoSurface(std::string const& format, unsigned int width, unsigned int height);
     static cairo_status_t write_callback(void *closure,
                                          const unsigned char *data,

--- a/src/mapnik_geometry.cpp
+++ b/src/mapnik_geometry.cpp
@@ -239,7 +239,7 @@ NAN_METHOD(Geometry::toJSON)
                 return;
             }
             closure->tr = Nan::ObjectWrap::Unwrap<ProjTransform>(obj);
-            closure->tr->_ref();
+            closure->tr->Ref();
         }
     }
     v8::Local<v8::Value> callback = info[info.Length()-1];
@@ -312,7 +312,7 @@ void Geometry::after_to_json(uv_work_t* req)
     }
     closure->g->Unref();
     if (closure->tr) {
-        closure->tr->_unref();
+        closure->tr->Unref();
     }
     closure->cb.Reset();
     delete closure;

--- a/src/mapnik_grid.hpp
+++ b/src/mapnik_grid.hpp
@@ -41,8 +41,9 @@ public:
 
     static NAN_GETTER(get_key);
     static NAN_SETTER(set_key);
-    void _ref() { Ref(); }
-    void _unref() { Unref(); }
+
+    using Nan::ObjectWrap::Ref;
+    using Nan::ObjectWrap::Unref;
 
     Grid(unsigned int width, unsigned int height, std::string const& key);
     inline grid_ptr get() { return this_; }

--- a/src/mapnik_grid_view.cpp
+++ b/src/mapnik_grid_view.cpp
@@ -40,12 +40,12 @@ GridView::GridView(Grid * JSGrid) :
     Nan::ObjectWrap(),
     this_(),
     JSGrid_(JSGrid) {
-        JSGrid_->_ref();
+        JSGrid_->Ref();
     }
 
 GridView::~GridView()
 {
-    JSGrid_->_unref();
+    JSGrid_->Unref();
 }
 
 NAN_METHOD(GridView::New)

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -1616,9 +1616,16 @@ void Image::EIO_AfterCopy(uv_work_t* req)
         Image* im = new Image(closure->im2);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        if (maybe_local.IsEmpty())
+        {
+            v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+        }
+        else
+        {
+            v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        }
     }
     closure->im1->Unref();
     closure->cb.Reset();
@@ -2125,9 +2132,16 @@ void Image::EIO_AfterResize(uv_work_t* req)
         Image* im = new Image(closure->im2);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        if (maybe_local.IsEmpty())
+        {
+            v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+        }
+        else
+        {
+            v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        }
     }
     closure->im1->Unref();
     closure->cb.Reset();
@@ -2595,9 +2609,16 @@ void Image::EIO_AfterOpen(uv_work_t* req)
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        if (maybe_local.IsEmpty())
+        {
+            v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+        }
+        else
+        {
+            v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        }
     }
     closure->cb.Reset();
     delete closure;
@@ -3079,9 +3100,16 @@ void Image::EIO_AfterFromSVG(uv_work_t* req)
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        if (maybe_local.IsEmpty())
+        {
+            v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+        }
+        else
+        {
+            v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        }
     }
     closure->cb.Reset();
     delete closure;
@@ -3310,9 +3338,16 @@ void Image::EIO_AfterFromSVGBytes(uv_work_t* req)
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        if (maybe_local.IsEmpty())
+        {
+            v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+        }
+        else
+        {
+            v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        }
     }
     closure->cb.Reset();
     closure->buffer.Reset();
@@ -3656,9 +3691,16 @@ void Image::EIO_AfterFromBytes(uv_work_t* req)
         Image* im = new Image(closure->im);
         v8::Local<v8::Value> ext = Nan::New<v8::External>(im);
         Nan::MaybeLocal<v8::Object> maybe_local = Nan::NewInstance(Nan::New(constructor)->GetFunction(), 1, &ext);
-        if (maybe_local.IsEmpty()) Nan::ThrowError("Could not create new Image instance");
-        v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
-        Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        if (maybe_local.IsEmpty())
+        {
+            v8::Local<v8::Value> argv[1] = { Nan::Error("Could not create new Image instance") };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 1, argv);
+        }
+        else
+        {
+            v8::Local<v8::Value> argv[2] = { Nan::Null(), maybe_local.ToLocalChecked() };
+            Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(closure->cb), 2, argv);
+        }
     }
     closure->cb.Reset();
     closure->buffer.Reset();

--- a/src/mapnik_image.hpp
+++ b/src/mapnik_image.hpp
@@ -114,8 +114,8 @@ public:
     static NAN_GETTER(get_offset);
     static NAN_SETTER(set_offset);
 
-    void _ref() { Ref(); }
-    void _unref() { Unref(); }
+    using Nan::ObjectWrap::Ref;
+    using Nan::ObjectWrap::Unref;
 
     Image(unsigned int width, unsigned int height, mapnik::image_dtype type, bool initialized, bool premultiplied, bool painted);
     Image(image_ptr this_);

--- a/src/mapnik_image_view.cpp
+++ b/src/mapnik_image_view.cpp
@@ -56,12 +56,12 @@ ImageView::ImageView(Image * JSImage) :
     Nan::ObjectWrap(),
     this_(),
     JSImage_(JSImage) {
-        JSImage_->_ref();
+        JSImage_->Ref();
     }
 
 ImageView::~ImageView()
 {
-    JSImage_->_unref();
+    JSImage_->Unref();
 }
 
 NAN_METHOD(ImageView::New)

--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -1855,7 +1855,7 @@ NAN_METHOD(Map::render)
             closure->request.data = closure;
             closure->m = m;
             closure->im = Nan::ObjectWrap::Unwrap<Image>(obj);
-            closure->im->_ref();
+            closure->im->Ref();
             closure->buffer_size = buffer_size;
             closure->scale_factor = scale_factor;
             closure->scale_denominator = scale_denominator;
@@ -1983,7 +1983,7 @@ NAN_METHOD(Map::render)
             closure->request.data = closure;
             closure->m = m;
             closure->g = g;
-            closure->g->_ref();
+            closure->g->Ref();
             closure->layer_idx = layer_idx;
             closure->buffer_size = buffer_size;
             closure->scale_factor = scale_factor;
@@ -2163,7 +2163,7 @@ NAN_METHOD(Map::render)
             closure->request.data = closure;
             closure->m = m;
             closure->d = Nan::ObjectWrap::Unwrap<VectorTile>(obj);
-            closure->d->_ref();
+            closure->d->Ref();
             closure->scale_factor = scale_factor;
             closure->scale_denominator = scale_denominator;
             closure->offset_x = offset_x;
@@ -2246,7 +2246,7 @@ void Map::EIO_AfterRenderVectorTile(uv_work_t* req)
     }
 
     closure->m->Unref();
-    closure->d->_unref();
+    closure->d->Unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -2310,7 +2310,7 @@ void Map::EIO_AfterRenderGrid(uv_work_t* req)
     }
 
     closure->m->Unref();
-    closure->g->_unref();
+    closure->g->Unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -2395,7 +2395,7 @@ void Map::EIO_AfterRenderImage(uv_work_t* req)
     }
 
     closure->m->Unref();
-    closure->im->_unref();
+    closure->im->Unref();
     closure->cb.Reset();
     delete closure;
 }

--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -1855,7 +1855,6 @@ NAN_METHOD(Map::render)
             closure->request.data = closure;
             closure->m = m;
             closure->im = Nan::ObjectWrap::Unwrap<Image>(obj);
-            closure->im->Ref();
             closure->buffer_size = buffer_size;
             closure->scale_factor = scale_factor;
             closure->scale_denominator = scale_denominator;
@@ -1882,7 +1881,7 @@ NAN_METHOD(Map::render)
             }
             closure->cb.Reset(info[info.Length() - 1].As<v8::Function>());
             uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderImage, (uv_after_work_cb)EIO_AfterRenderImage);
-
+            closure->im->Ref();
         }
 #if defined(GRID_RENDERER)
         else if (Nan::New(Grid::constructor)->HasInstance(obj)) {
@@ -1983,7 +1982,6 @@ NAN_METHOD(Map::render)
             closure->request.data = closure;
             closure->m = m;
             closure->g = g;
-            closure->g->Ref();
             closure->layer_idx = layer_idx;
             closure->buffer_size = buffer_size;
             closure->scale_factor = scale_factor;
@@ -1999,6 +1997,7 @@ NAN_METHOD(Map::render)
             }
             closure->cb.Reset(info[info.Length() - 1].As<v8::Function>());
             uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderGrid, (uv_after_work_cb)EIO_AfterRenderGrid);
+            closure->g->Ref();
         }
 #endif
         else if (Nan::New(VectorTile::constructor)->HasInstance(obj))
@@ -2163,7 +2162,6 @@ NAN_METHOD(Map::render)
             closure->request.data = closure;
             closure->m = m;
             closure->d = Nan::ObjectWrap::Unwrap<VectorTile>(obj);
-            closure->d->Ref();
             closure->scale_factor = scale_factor;
             closure->scale_denominator = scale_denominator;
             closure->offset_x = offset_x;
@@ -2177,6 +2175,7 @@ NAN_METHOD(Map::render)
             }
             closure->cb.Reset(info[info.Length() - 1].As<v8::Function>());
             uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderVectorTile, (uv_after_work_cb)EIO_AfterRenderVectorTile);
+            closure->d->Ref();
         }
         else
         {

--- a/src/mapnik_map.hpp
+++ b/src/mapnik_map.hpp
@@ -89,8 +89,9 @@ public:
 
     bool acquire();
     void release();
-    void _ref() { Ref(); }
-    void _unref() { Unref(); }
+
+    using Nan::ObjectWrap::Ref;
+    using Nan::ObjectWrap::Unref;
 
     inline map_ptr get() { return map_; }
 

--- a/src/mapnik_projection.hpp
+++ b/src/mapnik_projection.hpp
@@ -52,8 +52,8 @@ public:
 
     inline proj_tr_ptr get() { return this_; }
 
-    void _ref() { Ref(); }
-    void _unref() { Unref(); }
+    using Nan::ObjectWrap::Ref;
+    using Nan::ObjectWrap::Unref;
 
 private:
     ~ProjTransform();

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -3558,7 +3558,7 @@ NAN_METHOD(VectorTile::addImage)
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_AddImage, (uv_after_work_cb)EIO_AfterAddImage);
     d->Ref();
-    im->_ref();
+    im->Ref();
     return;
 }
 
@@ -3611,7 +3611,7 @@ void VectorTile::EIO_AfterAddImage(uv_work_t* req)
     }
 
     closure->d->Unref();
-    closure->im->_unref();
+    closure->im->Unref();
     closure->cb.Reset();
     delete closure;
 }
@@ -4706,7 +4706,7 @@ struct deref_visitor
     {
         if (surface != nullptr)
         {
-            surface->_unref();
+            surface->Unref();
         }
     }
 };
@@ -4978,7 +4978,7 @@ NAN_METHOD(VectorTile::render)
     if (Nan::New(Image::constructor)->HasInstance(im_obj))
     {
         Image *im = Nan::ObjectWrap::Unwrap<Image>(im_obj);
-        im->_ref();
+        im->Ref();
         closure->width = im->get()->width();
         closure->height = im->get()->height();
         closure->surface = im;
@@ -4986,7 +4986,7 @@ NAN_METHOD(VectorTile::render)
     else if (Nan::New(CairoSurface::constructor)->HasInstance(im_obj))
     {
         CairoSurface *c = Nan::ObjectWrap::Unwrap<CairoSurface>(im_obj);
-        c->_ref();
+        c->Ref();
         closure->width = c->width();
         closure->height = c->height();
         closure->surface = c;
@@ -5018,7 +5018,7 @@ NAN_METHOD(VectorTile::render)
     else if (Nan::New(Grid::constructor)->HasInstance(im_obj))
     {
         Grid *g = Nan::ObjectWrap::Unwrap<Grid>(im_obj);
-        g->_ref();
+        g->Ref();
         closure->width = g->get()->width();
         closure->height = g->get()->height();
         closure->surface = g;
@@ -5119,7 +5119,7 @@ NAN_METHOD(VectorTile::render)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderTile, (uv_after_work_cb)EIO_AfterRenderTile);
-    m->_ref();
+    m->Ref();
     d->Ref();
     guard.release();
     return;
@@ -5355,7 +5355,7 @@ void VectorTile::EIO_AfterRenderTile(uv_work_t* req)
         }
     }
 
-    closure->m->_unref();
+    closure->m->Unref();
     closure->d->Unref();
     closure->cb.Reset();
     delete closure;

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -4698,6 +4698,20 @@ using surface_type = mapnik::util::variant
 #endif
      >;
 
+struct ref_visitor
+{
+    void operator() (dummy_surface) {} // no-op
+    template <typename SurfaceType>
+    void operator() (SurfaceType * surface)
+    {
+        if (surface != nullptr)
+        {
+            surface->Ref();
+        }
+    }
+};
+
+
 struct deref_visitor
 {
     void operator() (dummy_surface) {} // no-op
@@ -4755,11 +4769,6 @@ struct vector_tile_render_baton_t
         zxy_override(false),
         error(false)
         {}
-
-    ~vector_tile_render_baton_t()
-    {
-        mapnik::util::apply_visitor(deref_visitor(),surface);
-    }
 };
 
 struct baton_guard
@@ -4978,7 +4987,6 @@ NAN_METHOD(VectorTile::render)
     if (Nan::New(Image::constructor)->HasInstance(im_obj))
     {
         Image *im = Nan::ObjectWrap::Unwrap<Image>(im_obj);
-        im->Ref();
         closure->width = im->get()->width();
         closure->height = im->get()->height();
         closure->surface = im;
@@ -4986,7 +4994,6 @@ NAN_METHOD(VectorTile::render)
     else if (Nan::New(CairoSurface::constructor)->HasInstance(im_obj))
     {
         CairoSurface *c = Nan::ObjectWrap::Unwrap<CairoSurface>(im_obj);
-        c->Ref();
         closure->width = c->width();
         closure->height = c->height();
         closure->surface = c;
@@ -5018,7 +5025,6 @@ NAN_METHOD(VectorTile::render)
     else if (Nan::New(Grid::constructor)->HasInstance(im_obj))
     {
         Grid *g = Nan::ObjectWrap::Unwrap<Grid>(im_obj);
-        g->Ref();
         closure->width = g->get()->width();
         closure->height = g->get()->height();
         closure->surface = g;
@@ -5119,6 +5125,7 @@ NAN_METHOD(VectorTile::render)
     closure->error = false;
     closure->cb.Reset(callback.As<v8::Function>());
     uv_queue_work(uv_default_loop(), &closure->request, EIO_RenderTile, (uv_after_work_cb)EIO_AfterRenderTile);
+    mapnik::util::apply_visitor(ref_visitor(), closure->surface);
     m->Ref();
     d->Ref();
     guard.release();
@@ -5355,6 +5362,7 @@ void VectorTile::EIO_AfterRenderTile(uv_work_t* req)
         }
     }
 
+    mapnik::util::apply_visitor(deref_visitor(), closure->surface);
     closure->m->Unref();
     closure->d->Unref();
     closure->cb.Reset();

--- a/src/mapnik_vector_tile.hpp
+++ b/src/mapnik_vector_tile.hpp
@@ -190,15 +190,8 @@ public:
         return tile_;
     }
     
-    void _ref()
-    { 
-        Ref(); 
-    }
-    
-    void _unref()
-    { 
-        Unref(); 
-    }
+    using Nan::ObjectWrap::Ref;
+    using Nan::ObjectWrap::Unref;
 
 private:
     mapnik::vector_tile_impl::merc_tile_ptr tile_;


### PR DESCRIPTION
This PR does 3 things:
As some classes had auxiliar functions to set or unset a reference before executing an async function that depended on them, but others didn't I've force all classes to have them and use them; so instead of calling `->Ref()` or `->_ref()` (which one was used was apparently random), now the code always uses `_ref()` and `_unref().

Making use of these auxiliar functions and some hooks (or printfs) I detected 2 structures that could leave some object referenced after passing through an async call, which means resource leakage.

- Some functions would set up a reference to an object (an Image for example), then do some error checking and then call the async callback. The issue appears if an error is detected after adding the reference, as it wasn't removed before throwing. To fix that I've just deferred all references to the end.

- Some functions would after doing the task, while setting up the callback. This means that the cleanup step of unreferencing objects (map, images, mvts...) isn't done. To address this I've removed those exception calls and used the callback(error) structure instead.