### PR TITLE
Call Nan::AdjustExternalMemory to help GC track memory usage.

### DIFF
--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -95,7 +95,7 @@ inline Nan::MaybeLocal<v8::Object> NewBufferFrom(std::unique_ptr<std::string> &&
                                                      }, ptr.get());
     if (!res.IsEmpty())
     {
-        Nan::AdjustExternalMemory(static_cast<std::int64_t>(ptr->capacity()));
+        Nan::AdjustExternalMemory(ptr->capacity());
         ptr.release();
 
     }


### PR DESCRIPTION
##### NOTE: 
* we pass std::string* as hint to ensure it's properly destroyed by its own dtor
* +/-buffer_size external memory adjustment is an approximation (via capacity())

