### PR TITLE
Fix grammar in error messages

### DIFF
--- a/src/blend.cpp
+++ b/src/blend.cpp
@@ -36,7 +36,7 @@ static bool hexToUInt32Color(char const* hex, std::uint32_t& value)
 {
     if (!hex) return false;
     std::size_t len_original = strlen(hex);
-    // Return is the length of the string is less then six
+    // Return if the length of the string is less than six
     // otherwise the line after this could go to some other
     // pointer in memory, resulting in strange behaviours.
     if (len_original < 6) return false;

--- a/src/mapnik_cairo_surface.cpp
+++ b/src/mapnik_cairo_surface.cpp
@@ -33,7 +33,7 @@ CairoSurface::CairoSurface(Napi::CallbackInfo const& info)
         format_ = info[0].As<Napi::String>();
         if (!info[1].IsNumber() || !info[2].IsNumber())
         {
-            Napi::TypeError::New(env, "CairoSurface 'width' and 'height' must be a integers").ThrowAsJavaScriptException();
+            Napi::TypeError::New(env, "CairoSurface 'width' and 'height' must be integers").ThrowAsJavaScriptException();
             return;
         }
         width_ = info[1].As<Napi::Number>().Int32Value();

--- a/src/mapnik_grid.cpp
+++ b/src/mapnik_grid.cpp
@@ -165,7 +165,7 @@ Grid::Grid(Napi::CallbackInfo const& info)
     {
         if (!info[0].IsNumber() || !info[1].IsNumber())
         {
-            Napi::TypeError::New(env, "Grid 'width' and 'height' must be a integers").ThrowAsJavaScriptException();
+            Napi::TypeError::New(env, "Grid 'width' and 'height' must be integers").ThrowAsJavaScriptException();
             return;
         }
 

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -113,7 +113,7 @@ Image::Image(Napi::CallbackInfo const& info)
         bool painted = false;
         if (!info[0].IsNumber() || !info[1].IsNumber())
         {
-            Napi::TypeError::New(env, "Image 'width' and 'height' must be a integers").ThrowAsJavaScriptException();
+            Napi::TypeError::New(env, "Image 'width' and 'height' must be integers").ThrowAsJavaScriptException();
             return;
         }
         if (info.Length() >= 3)

--- a/src/mapnik_image_from_bytes.cpp
+++ b/src/mapnik_image_from_bytes.cpp
@@ -266,7 +266,7 @@ Napi::Value Image::fromBufferSync(Napi::CallbackInfo const& info)
 
     if (width <= 0 || height <= 0)
     {
-        Napi::TypeError::New(env, "width and height must be greater then zero").ThrowAsJavaScriptException();
+        Napi::TypeError::New(env, "width and height must be greater than zero").ThrowAsJavaScriptException();
         return env.Undefined();
     }
 

--- a/src/mapnik_image_from_svg.cpp
+++ b/src/mapnik_image_from_svg.cpp
@@ -76,7 +76,7 @@ struct AsyncFromSVG : Napi::AsyncWorker
 
             if (svg_width <= 0 || svg_height <= 0)
             {
-                SetError("image created from svg must have a width and height greater then zero");
+                SetError("image created from svg must have a width and height greater than zero");
                 return;
             }
 
@@ -197,7 +197,7 @@ struct AsyncFromSVGBytes : Napi::AsyncWorker
 
             if (svg_width <= 0 || svg_height <= 0)
             {
-                SetError("image created from svg must have a width and height greater then zero");
+                SetError("image created from svg must have a width and height greater than zero");
                 return;
             }
 
@@ -397,7 +397,7 @@ Napi::Value Image::from_svg_sync_impl(Napi::CallbackInfo const& info, bool from_
 
         if (svg_width <= 0 || svg_height <= 0)
         {
-            Napi::TypeError::New(env, "image created from svg must have a width and height greater then zero").ThrowAsJavaScriptException();
+            Napi::TypeError::New(env, "image created from svg must have a width and height greater than zero").ThrowAsJavaScriptException();
             return env.Undefined();
         }
 

--- a/src/mapnik_image_resize.cpp
+++ b/src/mapnik_image_resize.cpp
@@ -154,7 +154,7 @@ struct AsyncResize : Napi::AsyncWorker
             image_out_->set_scaling(scaling);
             if (offset_width_ <= 0 || offset_height_ <= 0)
             {
-                SetError("Image width or height is zero or less then zero.");
+                SetError("Image width or height is zero or less than zero.");
                 return;
             }
 
@@ -252,7 +252,7 @@ Napi::Value Image::resize(Napi::CallbackInfo const& info)
             auto width_tmp = info[0].As<Napi::Number>().Int32Value();
             if (width_tmp <= 0)
             {
-                Napi::TypeError::New(env, "Width must be a integer greater then zero").ThrowAsJavaScriptException();
+                Napi::TypeError::New(env, "Width must be an integer greater than zero").ThrowAsJavaScriptException();
                 return env.Undefined();
             }
             width = static_cast<std::size_t>(width_tmp);
@@ -267,7 +267,7 @@ Napi::Value Image::resize(Napi::CallbackInfo const& info)
             auto height_tmp = info[1].As<Napi::Number>().Int32Value();
             if (height_tmp <= 0)
             {
-                Napi::TypeError::New(env, "Height must be a integer greater then zero").ThrowAsJavaScriptException();
+                Napi::TypeError::New(env, "Height must be an integer greater than zero").ThrowAsJavaScriptException();
                 return env.Undefined();
             }
             height = static_cast<std::size_t>(height_tmp);
@@ -326,7 +326,7 @@ Napi::Value Image::resize(Napi::CallbackInfo const& info)
         offset_width = bind_opt.As<Napi::Number>().DoubleValue();
         if (offset_width <= 0.0)
         {
-            Napi::TypeError::New(env, "optional arg 'offset_width' must be a integer greater then zero").ThrowAsJavaScriptException();
+            Napi::TypeError::New(env, "optional arg 'offset_width' must be an integer greater than zero").ThrowAsJavaScriptException();
             return env.Undefined();
         }
     }
@@ -341,7 +341,7 @@ Napi::Value Image::resize(Napi::CallbackInfo const& info)
         offset_height = bind_opt.As<Napi::Number>().DoubleValue();
         if (offset_height <= 0.0)
         {
-            Napi::TypeError::New(env, "optional arg 'offset_height' must be a integer greater then zero").ThrowAsJavaScriptException();
+            Napi::TypeError::New(env, "optional arg 'offset_height' must be an integer greater than zero").ThrowAsJavaScriptException();
             return env.Undefined();
         }
     }
@@ -428,7 +428,7 @@ Napi::Value Image::resizeSync(Napi::CallbackInfo const& info)
             int width_tmp = info[0].As<Napi::Number>().Int32Value();
             if (width_tmp <= 0)
             {
-                Napi::TypeError::New(env, "Width parameter must be an integer greater then zero").ThrowAsJavaScriptException();
+                Napi::TypeError::New(env, "Width parameter must be an integer greater than zero").ThrowAsJavaScriptException();
                 return env.Undefined();
             }
             width = static_cast<std::size_t>(width_tmp);
@@ -444,7 +444,7 @@ Napi::Value Image::resizeSync(Napi::CallbackInfo const& info)
             int height_tmp = info[1].As<Napi::Number>().Int32Value();
             if (height_tmp <= 0)
             {
-                Napi::TypeError::New(env, "Height parameter must be an integer greater then zero").ThrowAsJavaScriptException();
+                Napi::TypeError::New(env, "Height parameter must be an integer greater than zero").ThrowAsJavaScriptException();
                 return env.Undefined();
             }
             height = static_cast<std::size_t>(height_tmp);
@@ -504,7 +504,7 @@ Napi::Value Image::resizeSync(Napi::CallbackInfo const& info)
         offset_width = bind_opt.As<Napi::Number>().DoubleValue();
         if (offset_width <= 0.0)
         {
-            Napi::TypeError::New(env, "optional arg 'offset_width' must be a integer greater then zero").ThrowAsJavaScriptException();
+            Napi::TypeError::New(env, "optional arg 'offset_width' must be an integer greater than zero").ThrowAsJavaScriptException();
             return env.Undefined();
         }
     }
@@ -519,7 +519,7 @@ Napi::Value Image::resizeSync(Napi::CallbackInfo const& info)
         offset_height = bind_opt.As<Napi::Number>().DoubleValue();
         if (offset_height <= 0.0)
         {
-            Napi::TypeError::New(env, "optional arg 'offset_height' must be a integer greater then zero").ThrowAsJavaScriptException();
+            Napi::TypeError::New(env, "optional arg 'offset_height' must be an integer greater than zero").ThrowAsJavaScriptException();
             return env.Undefined();
         }
     }
@@ -564,7 +564,7 @@ Napi::Value Image::resizeSync(Napi::CallbackInfo const& info)
     }
     if (offset_width <= 0 || offset_height <= 0)
     {
-        Napi::TypeError::New(env, "Image width or height is zero or less then zero.").ThrowAsJavaScriptException();
+        Napi::TypeError::New(env, "Image width or height is zero or less than zero.").ThrowAsJavaScriptException();
         return env.Undefined();
     }
     try

--- a/src/mapnik_vector_tile.cpp
+++ b/src/mapnik_vector_tile.cpp
@@ -137,7 +137,7 @@ VectorTile::VectorTile(Napi::CallbackInfo const& info)
         !info[1].IsNumber() ||
         !info[2].IsNumber())
     {
-        Napi::TypeError::New(env, "required parameters (z, x, and y) must be a integers").ThrowAsJavaScriptException();
+        Napi::TypeError::New(env, "required parameters (z, x, and y) must be integers").ThrowAsJavaScriptException();
         return;
     }
 
@@ -146,7 +146,7 @@ VectorTile::VectorTile(Napi::CallbackInfo const& info)
     std::int64_t y = info[2].As<Napi::Number>().Int64Value();
     if (z < 0 || x < 0 || y < 0)
     {
-        Napi::TypeError::New(env, "required parameters (z, x, and y) must be greater then or equal to zero").ThrowAsJavaScriptException();
+        Napi::TypeError::New(env, "required parameters (z, x, and y) must be greater than or equal to zero").ThrowAsJavaScriptException();
         return;
     }
     std::int64_t max_at_zoom = pow(2, z);
@@ -183,7 +183,7 @@ VectorTile::VectorTile(Napi::CallbackInfo const& info)
             int tile_size_tmp = opt.As<Napi::Number>().Int32Value();
             if (tile_size_tmp <= 0)
             {
-                Napi::TypeError::New(env, "optional arg 'tile_size' must be greater then zero").ThrowAsJavaScriptException();
+                Napi::TypeError::New(env, "optional arg 'tile_size' must be greater than zero").ThrowAsJavaScriptException();
                 return;
             }
             tile_size = tile_size_tmp;
@@ -476,7 +476,7 @@ void VectorTile::set_tile_x(Napi::CallbackInfo const& info, const Napi::Value& v
         int val = value.As<Napi::Number>().Int32Value();
         if (val < 0)
         {
-            Napi::Error::New(env, "tile x coordinate must be greater then or equal to zero").ThrowAsJavaScriptException();
+            Napi::Error::New(env, "tile x coordinate must be greater than or equal to zero").ThrowAsJavaScriptException();
             return;
         }
         tile_->x(val);
@@ -495,7 +495,7 @@ void VectorTile::set_tile_y(Napi::CallbackInfo const& info, const Napi::Value& v
         int val = value.As<Napi::Number>().Int32Value();
         if (val < 0)
         {
-            Napi::Error::New(env, "tile y coordinate must be greater then or equal to zero").ThrowAsJavaScriptException();
+            Napi::Error::New(env, "tile y coordinate must be greater than or equal to zero").ThrowAsJavaScriptException();
             return;
         }
         tile_->y(val);
@@ -514,7 +514,7 @@ void VectorTile::set_tile_z(Napi::CallbackInfo const& info, const Napi::Value& v
         int val = value.As<Napi::Number>().Int32Value();
         if (val < 0)
         {
-            Napi::Error::New(env, "tile z coordinate must be greater then or equal to zero").ThrowAsJavaScriptException();
+            Napi::Error::New(env, "tile z coordinate must be greater than or equal to zero").ThrowAsJavaScriptException();
             return;
         }
         tile_->z(val);
@@ -533,7 +533,7 @@ void VectorTile::set_tile_size(Napi::CallbackInfo const& info, const Napi::Value
         int val = value.As<Napi::Number>().Int32Value();
         if (val <= 0)
         {
-            Napi::Error::New(env, "tile size must be greater then zero").ThrowAsJavaScriptException();
+            Napi::Error::New(env, "tile size must be greater than zero").ThrowAsJavaScriptException();
             return;
         }
         tile_->tile_size(val);

--- a/src/mapnik_vector_tile_composite.cpp
+++ b/src/mapnik_vector_tile_composite.cpp
@@ -212,7 +212,7 @@ Napi::Value VectorTile::compositeSync(Napi::CallbackInfo const& info)
             scale_factor = bind_opt.As<Napi::Number>().DoubleValue();
             if (scale_factor <= 0.0)
             {
-                Napi::TypeError::New(env, "optional arg 'scale' must be greater then zero").ThrowAsJavaScriptException();
+                Napi::TypeError::New(env, "optional arg 'scale' must be greater than zero").ThrowAsJavaScriptException();
                 return env.Undefined();
             }
         }

--- a/src/mapnik_vector_tile_image.cpp
+++ b/src/mapnik_vector_tile_image.cpp
@@ -68,7 +68,7 @@ Napi::Value VectorTile::addImageSync(Napi::CallbackInfo const& info)
     Image* im = Napi::ObjectWrap<Image>::Unwrap(obj);
     if (im->impl()->width() <= 0 || im->impl()->height() <= 0)
     {
-        Napi::Error::New(env, "Image width and height must be greater then zero").ThrowAsJavaScriptException();
+        Napi::Error::New(env, "Image width and height must be greater than zero").ThrowAsJavaScriptException();
         return env.Undefined();
     }
 
@@ -262,7 +262,7 @@ Napi::Value VectorTile::addImage(Napi::CallbackInfo const& info)
     Image* im = Napi::ObjectWrap<Image>::Unwrap(obj);
     if (im->impl()->width() <= 0 || im->impl()->height() <= 0)
     {
-        Napi::Error::New(env, "Image width and height must be greater then zero").ThrowAsJavaScriptException();
+        Napi::Error::New(env, "Image width and height must be greater than zero").ThrowAsJavaScriptException();
         return env.Undefined();
     }
 

--- a/test/image.svg.test.js
+++ b/test/image.svg.test.js
@@ -59,7 +59,7 @@ test('should throw with invalid usage', (assert) => {
   }, /'scale' must be a positive non zero number/);
   assert.throws(function() {
     mapnik.Image.fromSVGSync('./test/data/vector_tile/tile0.corrupt-svg.svg');
-  }, /image created from svg must have a width and height greater then zero/);
+  }, /image created from svg must have a width and height greater than zero/);
 
   mapnik.Image.fromSVGBytes(Buffer.from('a'), { scale: 1 }, function(err, res) {
     assert.ok(err);
@@ -117,7 +117,7 @@ test('max image size blocks dimension*scale', (assert) => {
 test('should err with async file w/o width or height', (assert) => {
   mapnik.Image.fromSVG('./test/data/vector_tile/tile0.corrupt-svg.svg', function(err, svg) {
     assert.ok(err);
-    assert.ok(err.message.match(/image created from svg must have a width and height greater then zero/));
+    assert.ok(err.message.match(/image created from svg must have a width and height greater than zero/));
     assert.equal(svg, undefined);
     assert.end();
   });
@@ -128,7 +128,7 @@ test('should err with async file w/o width or height as Bytes', (assert) => {
   var buffer = Buffer.from(svgdata);
   mapnik.Image.fromSVGBytes(buffer, function(err, img) {
     assert.ok(err);
-    assert.ok(err.message.match(/image created from svg must have a width and height greater then zero/));
+    assert.ok(err.message.match(/image created from svg must have a width and height greater than zero/));
     assert.equal(img, undefined);
     assert.end();
   });

--- a/test/vector-tile.test.js
+++ b/test/vector-tile.test.js
@@ -740,7 +740,7 @@ test('should accept optional bufferSize', (assert) => {
   assert.throws(function() { new mapnik.VectorTile(0,0,0,{buffer_size:null});});
   assert.throws(function() { new mapnik.VectorTile(0,0,0,{buffer_size:-2048});});
   assert.throws(function() { vtile.bufferSize = 'asdf'; });
-  assert.throws(function() { vtile.bufferSize = -2048; }); // buffer size greater then tilesize supports
+  assert.throws(function() { vtile.bufferSize = -2048; }); // buffer size greater than tilesize supports
   assert.equal(vtile.bufferSize, 18);
   vtile.bufferSize = 512;
   assert.equal(vtile.bufferSize, 512);


### PR DESCRIPTION
This is not a comprehensive audit of grammar in this repo, but does fix some simple `a` &rarr; `an` and `then` &rarr; `than` mistakes in error messages.