### PR TITLE
use pkg-config as an alternative

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.vscode
+.git
+build
+node_modules
+package-lock.json
+vcpkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ghcr.io/mathisloge/mapnik:docker
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y nodejs npm git && mkdir /nodemapnik
+COPY . /nodemapnik
+
+WORKDIR /
+RUN git clone https://github.com/mapbox/mapnik-vector-tile.git mapnik-vector-tile \
+    && cd mapnik-vector-tile \
+    && git checkout proj6
+ 
+WORKDIR /nodemapnik
+RUN npm install
+RUN npm run test && rm -rf build

--- a/binding.gyp
+++ b/binding.gyp
@@ -79,7 +79,7 @@
         "<!(node -e \"require('mapnik-vector-tile')\")"
       ],
       'defines': [
-          'MAPNIK_GIT_REVISION="<!@(mapnik-config --git-describe)"',
+          'MAPNIK_GIT_REVISION="0"',
           'MAPNIK_VECTOR_TILE_LIBRARY=1',
       ],
       'conditions': [
@@ -91,22 +91,18 @@
         ['OS=="win"',
           {
             'include_dirs':[
-              '<!@(mapnik-config --includes)',
-              '<!@(mapnik-config --dep-includes)'
+              '<!@(pkg-config libmapnik --cflags-only-I)'
             ],
-            'defines': ['NOMINMAX','<!@(mapnik-config --defines)'],
+            'defines': ['NOMINMAX','<!@(pkg-config libmapnik --cflags-only-other)'],
             'defines!': ["_HAS_EXCEPTIONS=0"],
             'libraries': [
-              '<!@(mapnik-config --libs)',
-              'mapnik-wkt.lib',
-              'mapnik-json.lib',
-              '<!@(mapnik-config --dep-libs)',
+              '<!@(pkg-config libmapnik --libs)'
             ],
             'msvs_disabled_warnings': [ 4244,4005,4506,4345,4804,4805 ],
             'msvs_settings': {
               'VCLinkerTool': {
                 'AdditionalLibraryDirectories': [
-                  '<!@(mapnik-config --ldflags)'
+                  '<!@(pkg-config libmapnik --libs-only-L)'
                 ],
               },
             }
@@ -114,14 +110,10 @@
           {
             'cflags_cc!': ['-fno-rtti', '-fno-exceptions'],
             'cflags_cc' : [
-              '<!@(mapnik-config --cflags)',
+              '<!@(pkg-config libmapnik --cflags)',
             ],
             'libraries':[
-              '<!@(mapnik-config --libs)',
-              '-lmapnik-wkt',
-              '-lmapnik-json',
-              '<!@(mapnik-config --ldflags)',
-              '<!@(mapnik-config --dep-libs)'
+              '<!@(pkg-config libmapnik --libs)'
             ],
             'ldflags': [
               '-Wl,-z,now',
@@ -130,10 +122,10 @@
             ],
             'xcode_settings': {
               'OTHER_CPLUSPLUSFLAGS':[
-                '<!@(mapnik-config --cflags)',
+                '<!@(pkg-config libmapnik --cflags)',
               ],
               'OTHER_CFLAGS':[
-                '<!@(mapnik-config --cflags)'
+                '<!@(pkg-config libmapnik --cflags)'
               ],
               'OTHER_LDFLAGS':[
                 '-Wl,-bind_at_load'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "http://github.com/mapnik/node-mapnik",
   "homepage": "http://mapnik.org",
   "author": "Dane Springmeyer <dane@mapbox.com> (mapnik.org)",
-  "version": "4.5.9",
+  "version": "4.5.10-wip",
   "mapnik_version": "e553f55dc",
   "main": "./lib/mapnik.js",
   "binary": {

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -8,7 +8,22 @@ MAPNIK_SDK=./mason_packages/.link
 # Check if we are using Mason's mapnik
 # If not (and we are using a source install of mapnik rather than mason package)
 # then we only dump the mapnik_settings.js and then exit without copying data
-if [[ ! "$(which mapnik-config)" -ef "$MAPNIK_SDK/bin/mapnik-config" ]]; then
+if pkg-config libmapnik --exists ; then
+    echo "
+var path = require('path');
+module.exports.paths = {
+    'fonts':         '$(pkg-config libmapnik --variable prefix)/bin/fonts',
+    'input_plugins': '$(pkg-config libmapnik --variable libdir)/mapnik/input',
+    'mapnik_index':  '$(pkg-config libmapnik --variable prefix)/bin/mapnik-index',
+    'shape_index':   '$(pkg-config libmapnik --variable prefix)/bin/shapeindex'
+};
+module.exports.env = {
+    'ICU_DATA':      '',
+    'GDAL_DATA':     '',
+    'PROJ_LIB':      ''
+};
+" > ${MODULE_PATH}/mapnik_settings.js
+elif [[ ! "$(which mapnik-config)" -ef "$MAPNIK_SDK/bin/mapnik-config" ]]; then
     echo "
 var path = require('path');
 module.exports.paths = {

--- a/src/mapnik_map.cpp
+++ b/src/mapnik_map.cpp
@@ -85,7 +85,7 @@ Napi::Object Map::Initialize(Napi::Env env, Napi::Object exports, napi_property_
  * @param {int} width in pixels
  * @param {int} height in pixels
  * @param {string} [projection='+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'] projection as a proj4 code
- * typically used with '+init=epsg:3857'
+ * typically used with 'epsg:3857'
  * @property {string} src
  * @property {number} width
  * @property {number} height
@@ -97,7 +97,7 @@ Napi::Object Map::Initialize(Napi::Env env, Napi::Object exports, napi_property_
  * @property {} parameters
  * @property {} aspect_fix_mode
  * @example
- * var map = new mapnik.Map(600, 400, '+init=epsg:3857');
+ * var map = new mapnik.Map(600, 400, 'epsg:3857');
  * console.log(map);
  * // {
  * //   aspect_fix_mode: 0,
@@ -113,7 +113,7 @@ Napi::Object Map::Initialize(Napi::Env env, Napi::Object exports, napi_property_
  * //   bufferSize: 0,
  * //   height: 400,
  * //   width: 600,
- * //   srs: '+init=epsg:3857'
+ * //   srs: 'epsg:3857'
  * // }
  */
 

--- a/src/mapnik_projection.cpp
+++ b/src/mapnik_projection.cpp
@@ -36,7 +36,7 @@ Napi::Object Projection::Initialize(Napi::Env env, Napi::Object exports, napi_pr
  * @throws {Error} the projection could not be initialized - it was not found
  * in proj4's tables or the string was malformed
  * @example
- * var wgs84 = new mapnik.Projection('+init=epsg:4326');
+ * var wgs84 = new mapnik.Projection('epsg:4326');
  */
 
 Projection::Projection(Napi::CallbackInfo const& info)
@@ -87,7 +87,7 @@ Projection::Projection(Napi::CallbackInfo const& info)
  * @param {Array<number>} position as [x, y] or extent as [minx,miny,maxx,maxy]
  * @returns {Array<number>} projected coordinates
  * @example
- * var merc = new mapnik.Projection('+init=epsg:3857');
+ * var merc = new mapnik.Projection('epsg:3857');
  * var long_lat_coords = [-122.33517, 47.63752];
  * var projected = merc.forward(long_lat_coords);
  */
@@ -315,7 +315,7 @@ Napi::Value ProjTransform::forward(Napi::CallbackInfo const& info)
             {
                 std::ostringstream s;
                 s << "Failed to forward project "
-                  << x << "," << y << " from " << proj_transform_->source().params() << " to " << proj_transform_->dest().params();
+                  << x << "," << y << " " << proj_transform_->definition();
                 Napi::Error::New(env, s.str().c_str()).ThrowAsJavaScriptException();
                 return env.Undefined();
             }
@@ -334,7 +334,7 @@ Napi::Value ProjTransform::forward(Napi::CallbackInfo const& info)
             {
                 std::ostringstream s;
                 s << "Failed to forward project "
-                  << box << " from " << proj_transform_->source().params() << " to " << proj_transform_->dest().params();
+                  << box << " " << proj_transform_->definition();
                 Napi::Error::New(env, s.str()).ThrowAsJavaScriptException();
                 return env.Undefined();
             }
@@ -385,7 +385,7 @@ Napi::Value ProjTransform::backward(Napi::CallbackInfo const& info)
             {
                 std::ostringstream s;
                 s << "Failed to back project "
-                  << x << "," << y << " from " << proj_transform_->dest().params() << " to: " << proj_transform_->source().params();
+                  << x << "," << y << " " << proj_transform_->definition();
                 Napi::Error::New(env, s.str()).ThrowAsJavaScriptException();
                 return env.Null();
             }
@@ -404,7 +404,7 @@ Napi::Value ProjTransform::backward(Napi::CallbackInfo const& info)
             {
                 std::ostringstream s;
                 s << "Failed to back project "
-                  << box << " from " << proj_transform_->source().params() << " to " << proj_transform_->dest().params();
+                  << box << " " << proj_transform_->definition();
                 Napi::Error::New(env, s.str()).ThrowAsJavaScriptException();
                 return env.Null();
             }

--- a/src/mapnik_vector_tile_composite.cpp
+++ b/src/mapnik_vector_tile_composite.cpp
@@ -23,7 +23,7 @@ void _composite(tile_type target_tile,
                 std::launch threading_mode)
 {
     // create map
-    mapnik::Map map(target_tile->size(), target_tile->size(), "+init=epsg:3857");
+    mapnik::Map map(target_tile->size(), target_tile->size(), "epsg:3857");
     if (max_extent)
     {
         map.set_maximum_extent(*max_extent);
@@ -575,7 +575,7 @@ Napi::Value VectorTile::composite(Napi::CallbackInfo const& info)
     std::string image_format = "webp";
     mapnik::scaling_method_e scaling_method = mapnik::SCALING_BILINEAR;
     std::launch threading_mode = std::launch::deferred;
-    std::string merc_srs("+init=epsg:3857");
+    std::string merc_srs("epsg:3857");
 
     if (info.Length() > 2)
     {

--- a/src/mapnik_vector_tile_image.cpp
+++ b/src/mapnik_vector_tile_image.cpp
@@ -127,8 +127,8 @@ Napi::Value VectorTile::addImageSync(Napi::CallbackInfo const& info)
     try
     {
         // create map object
-        mapnik::Map map(tile_->size(), tile_->size(), "+init=epsg:3857");
-        mapnik::layer lyr(layer_name, "+init=epsg:3857");
+        mapnik::Map map(tile_->size(), tile_->size(), "epsg:3857");
+        mapnik::layer lyr(layer_name, "epsg:3857");
         lyr.set_datasource(ds);
         map.add_layer(lyr);
 
@@ -178,8 +178,8 @@ struct AsyncAddImage : Napi::AsyncWorker
             ds->envelope(); // can be removed later, currently doesn't work with out this.
             ds->set_envelope(tile_->extent());
             // create map object
-            mapnik::Map map(tile_->size(), tile_->size(), "+init=epsg:3857");
-            mapnik::layer lyr(layer_name_, "+init=epsg:3857");
+            mapnik::Map map(tile_->size(), tile_->size(), "epsg:3857");
+            mapnik::layer lyr(layer_name_, "epsg:3857");
             lyr.set_datasource(ds);
             map.add_layer(lyr);
 

--- a/src/mapnik_vector_tile_json.cpp
+++ b/src/mapnik_vector_tile_json.cpp
@@ -319,8 +319,8 @@ bool layer_to_geojson(protozero::pbf_reader const& layer,
                       unsigned z)
 {
     mapnik::vector_tile_impl::tile_datasource_pbf ds(layer, x, y, z);
-    mapnik::projection wgs84("+init=epsg:4326", true);
-    mapnik::projection merc("+init=epsg:3857", true);
+    mapnik::projection wgs84("epsg:4326", true);
+    mapnik::projection merc("epsg:3857", true);
     mapnik::proj_transform prj_trans(merc, wgs84);
     // This mega box ensures we capture all features, including those
     // outside the tile extent. Geometries outside the tile extent are
@@ -1095,11 +1095,11 @@ Napi::Value VectorTile::addGeoJSON(Napi::CallbackInfo const& info)
     {
         // create map object
         auto tile_size = tile_->tile_size();
-        mapnik::Map map(tile_size, tile_size, "+init=epsg:3857");
+        mapnik::Map map(tile_size, tile_size, "epsg:3857");
         mapnik::parameters p;
         p["type"] = "geojson";
         p["inline"] = geojson_string;
-        mapnik::layer lyr(geojson_name, "+init=epsg:4326");
+        mapnik::layer lyr(geojson_name, "epsg:4326");
         lyr.set_datasource(mapnik::datasource_cache::instance().create(p));
         map.add_layer(lyr);
 

--- a/src/mapnik_vector_tile_query.cpp
+++ b/src/mapnik_vector_tile_query.cpp
@@ -175,8 +175,8 @@ std::vector<query_result> _query(mapnik::vector_tile_impl::merc_tile_ptr const& 
         return arr;
     }
 
-    mapnik::projection wgs84("+init=epsg:4326", true);
-    mapnik::projection merc("+init=epsg:3857", true);
+    mapnik::projection wgs84("epsg:4326", true);
+    mapnik::projection merc("epsg:3857", true);
     mapnik::proj_transform tr(wgs84, merc);
     double x = lon;
     double y = lat;
@@ -385,8 +385,8 @@ void _queryMany(queryMany_result& result,
 
     // Reproject query => mercator points
     mapnik::box2d<double> bbox;
-    mapnik::projection wgs84("+init=epsg:4326", true);
-    mapnik::projection merc("+init=epsg:3857", true);
+    mapnik::projection wgs84("epsg:4326", true);
+    mapnik::projection merc("epsg:3857", true);
     mapnik::proj_transform tr(wgs84, merc);
     std::vector<mapnik::coord2d> points;
     points.reserve(query.size());

--- a/src/mapnik_vector_tile_simple_valid.cpp
+++ b/src/mapnik_vector_tile_simple_valid.cpp
@@ -371,8 +371,8 @@ void layer_not_valid(protozero::pbf_reader& layer_msg,
             {
                 if (lat_lon)
                 {
-                    mapnik::projection wgs84("+init=epsg:4326", true);
-                    mapnik::projection merc("+init=epsg:3857", true);
+                    mapnik::projection wgs84("epsg:4326", true);
+                    mapnik::projection merc("epsg:3857", true);
                     mapnik::proj_transform prj_trans(merc, wgs84);
                     unsigned int n_err = 0;
                     mapnik::util::apply_visitor(

--- a/test/data/large_overzoom.xml
+++ b/test/data/large_overzoom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" base="/Users/mthompson/src/api-maps/node_modules/mapbox-maps/node_modules/@mapbox/tilelive-vector/" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
+<Map srs="epsg:3857" base="/Users/mthompson/src/api-maps/node_modules/mapbox-maps/node_modules/@mapbox/tilelive-vector/" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
   <Parameters>
     <Parameter name="bounds">-180,-85.0511,180,85.0511</Parameter>
     <Parameter name="center">0,0,3</Parameter>
@@ -30,11 +30,11 @@
       <RasterSymbolizer opacity="1"/>
     </Rule>
   </Style>
-  <Layer name="_image" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  <Layer name="_image" srs="epsg:3857">
     <StyleName>_image</StyleName>
     <StyleName>_image-raster</StyleName>
   </Layer>
-  <Layer name="_image" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  <Layer name="_image" srs="epsg:3857">
     <StyleName>_image</StyleName>
   </Layer>
 </Map>

--- a/test/data/map.xml
+++ b/test/data/map.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="nz">
         <Rule>
@@ -19,7 +19,7 @@
         </Rule>
     </Style>
 
-    <Layer name="world" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="world" srs="epsg:3857">
         <StyleName>world</StyleName>
         <Datasource>
             <Parameter name="file">./world_merc.shp</Parameter>

--- a/test/data/markers.xml
+++ b/test/data/markers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -14,7 +14,7 @@
         </Rule>
     </Style>
 
-    <Layer name="world" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="world" srs="epsg:3857">
         <StyleName>style</StyleName>
         <StyleName>label</StyleName>
         <Datasource>

--- a/test/data/postgis_datasource_tokens_query.xml
+++ b/test/data/postgis_datasource_tokens_query.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+init=epsg:3857">
-  <Layer name="field_shapes" status="on" srs="+init=epsg:4326">
+<Map srs="epsg:3857">
+  <Layer name="field_shapes" status="on" srs="epsg:4326">
     <Datasource>
       <Parameter name="type">postgis</Parameter>
       <Parameter name="host">localhost</Parameter>

--- a/test/data/roads.xml
+++ b/test/data/roads.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE Map[]>
 <Map
-  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over"
+  srs="epsg:3857"
   font-directory="./dir-区县级行政区划/你好_DejaVuSansMono-BoldOblique.ttf"
   background-color="#dfd8c9">
 
@@ -79,7 +79,7 @@
   </Rule>
 </Style>
 <Layer name="layer"
-  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  srs="epsg:3857">
     <StyleName>casing</StyleName>
     <StyleName>bridge</StyleName>
     <StyleName>fill</StyleName>

--- a/test/data/sat_map.xml
+++ b/test/data/sat_map.xml
@@ -1,10 +1,10 @@
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+<Map srs="epsg:3857">
     <Style name="style">
         <Rule>
             <RasterSymbolizer scaling="sinc" filter-factor="2.0"/>
         </Rule>
     </Style>
-    <Layer name="raster" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="raster" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">./images/sat_image.png</Parameter>

--- a/test/data/ünicode_symbols.xml
+++ b/test/data/ünicode_symbols.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs" background-color="steelblue">
+<Map srs="epsg:4326" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="layer" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+    <Layer name="layer" srs="epsg:4326">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="type">csv</Parameter>
@@ -30,7 +30,7 @@ x,y
     </Style>
 
 
-    <Layer name="frame" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+    <Layer name="frame" srs="epsg:4326">
         <StyleName>frame</StyleName>
         <Datasource>
             <Parameter name="type">csv</Parameter>

--- a/test/data/vector_tile/compositing/badtile.xml
+++ b/test/data/vector_tile/compositing/badtile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="rgb(0,0,0)" base="/Users/mthompson/src/api-maps/node_modules/mapbox-maps/node_modules/tilelive-vector/" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
+<Map srs="epsg:3857" background-color="rgb(0,0,0)" base="/Users/mthompson/src/api-maps/node_modules/mapbox-maps/node_modules/tilelive-vector/" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">
   <Parameters>
     <Parameter name="bounds">-180,-85.0511,180,85.0511</Parameter>
     <Parameter name="center">0,0,3</Parameter>
@@ -79,19 +79,19 @@
       <RasterSymbolizer opacity="1"/>
     </Rule>
   </Style>
-  <Layer name="landcover" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  <Layer name="landcover" srs="epsg:3857">
     <StyleName>landcover</StyleName>
     <StyleName>landcover-raster</StyleName>
   </Layer>
-  <Layer name="hillshade" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  <Layer name="hillshade" srs="epsg:3857">
     <StyleName>hillshade</StyleName>
     <StyleName>hillshade-raster</StyleName>
   </Layer>
-  <Layer name="contour" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  <Layer name="contour" srs="epsg:3857">
     <StyleName>contour</StyleName>
     <StyleName>contour-raster</StyleName>
   </Layer>
-  <Layer name="_image" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+  <Layer name="_image" srs="epsg:3857">
     <StyleName>_image</StyleName>
   </Layer>
 </Map>

--- a/test/data/vector_tile/compositing/layers/lines.xml
+++ b/test/data/vector_tile/compositing/layers/lines.xml
@@ -1,4 +1,4 @@
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+<Map srs="epsg:3857">
 
     <Style name="lines">
         <Rule>
@@ -6,7 +6,7 @@
         </Rule>
     </Style>
 
-    <Layer name="lines" srs="+init=epsg:4326">
+    <Layer name="lines" srs="epsg:4326">
         <StyleName>lines</StyleName>
         <Datasource>
             <Parameter name="type">csv</Parameter>
@@ -17,5 +17,5 @@ wkt
             </Parameter>
         </Datasource>
     </Layer>
-    
+
 </Map>

--- a/test/data/vector_tile/compositing/layers/points.xml
+++ b/test/data/vector_tile/compositing/layers/points.xml
@@ -1,4 +1,4 @@
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" buffer-size="256">
+<Map srs="epsg:3857" buffer-size="256">
 
     <Style name="points">
         <Rule>
@@ -6,7 +6,7 @@
         </Rule>
     </Style>
 
-    <Layer name="points" srs="+init=epsg:4326">
+    <Layer name="points" srs="epsg:4326">
         <StyleName>points</StyleName>
         <Datasource>
             <Parameter name="type">csv</Parameter>
@@ -15,5 +15,5 @@ x,y
 0,0
             </Parameter>
         </Datasource>
-    </Layer>    
+    </Layer>
 </Map>

--- a/test/data/vector_tile/compositing/styles/all.xml
+++ b/test/data/vector_tile/compositing/styles/all.xml
@@ -1,15 +1,15 @@
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+<Map srs="epsg:3857">
     <Style name="raster" image-filters="agg-stack-blur(1,1) sharpen()">
         <Rule>
             <RasterSymbolizer opacity=".5" />
         </Rule>
     </Style>
 
-    <Layer name="raster" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="raster" srs="epsg:3857">
         <StyleName>raster</StyleName>
     </Layer>
 
-    <Layer name="raster2" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="raster2" srs="epsg:3857">
         <StyleName>raster</StyleName>
     </Layer>
 
@@ -23,31 +23,31 @@
         </Rule>
     </Style>
 
-    <Layer name="lines" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="lines" srs="epsg:3857">
         <StyleName>lines</StyleName>
     </Layer>
-    <Layer name="lines-0-0-0" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="lines-0-0-0" srs="epsg:3857">
         <StyleName>lines</StyleName>
     </Layer>
-    <Layer name="lines-1-0-0" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="lines-1-0-0" srs="epsg:3857">
         <StyleName>lines</StyleName>
     </Layer>
-    <Layer name="lines-1-0-1" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="lines-1-0-1" srs="epsg:3857">
         <StyleName>lines</StyleName>
     </Layer>
-    <Layer name="lines-1-1-0" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="lines-1-1-0" srs="epsg:3857">
         <StyleName>lines</StyleName>
     </Layer>
-    <Layer name="lines-1-1-1" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="lines-1-1-1" srs="epsg:3857">
         <StyleName>lines</StyleName>
     </Layer>
-    <Layer name="lines-2-0-0" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="lines-2-0-0" srs="epsg:3857">
         <StyleName>lines</StyleName>
     </Layer>
-    <Layer name="lines-2-0-1" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="lines-2-0-1" srs="epsg:3857">
         <StyleName>lines</StyleName>
     </Layer>
-    <Layer name="lines-2-1-1" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="lines-2-1-1" srs="epsg:3857">
         <StyleName>lines</StyleName>
     </Layer>
 
@@ -57,32 +57,32 @@
         </Rule>
     </Style>
 
-    <Layer name="points" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="points" srs="epsg:3857">
         <StyleName>points</StyleName>
     </Layer>
-    <Layer name="points-0-0-0" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="points-0-0-0" srs="epsg:3857">
         <StyleName>points</StyleName>
     </Layer>
-    <Layer name="points-1-0-0" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="points-1-0-0" srs="epsg:3857">
         <StyleName>points</StyleName>
     </Layer>
-    <Layer name="points-1-1-0" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="points-1-1-0" srs="epsg:3857">
         <StyleName>points</StyleName>
     </Layer>
-    <Layer name="points-1-0-1" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="points-1-0-1" srs="epsg:3857">
         <StyleName>points</StyleName>
     </Layer>
-    <Layer name="points-1-1-1" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="points-1-1-1" srs="epsg:3857">
         <StyleName>points</StyleName>
     </Layer>
-    <Layer name="points-2-0-0" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="points-2-0-0" srs="epsg:3857">
         <StyleName>points</StyleName>
     </Layer>
-    <Layer name="points-2-0-1" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="points-2-0-1" srs="epsg:3857">
         <StyleName>points</StyleName>
     </Layer>
-    <Layer name="points-2-1-1" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="points-2-1-1" srs="epsg:3857">
         <StyleName>points</StyleName>
     </Layer>
-    
+
 </Map>

--- a/test/data/vector_tile/generic_map.xml
+++ b/test/data/vector_tile/generic_map.xml
@@ -15,6 +15,6 @@
   </Rule>
 </Style>
 
-<Layer name="%s" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+<Layer name="%s" srs="epsg:3857">
     <StyleName>%s</StyleName>
 </Layer>

--- a/test/data/vector_tile/layers.xml
+++ b/test/data/vector_tile/layers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
-    <Layer name="world" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="world" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">../../data/world_merc.shp</Parameter>
@@ -10,7 +10,7 @@
         </Datasource>
     </Layer>
 
-    <Layer name="world2" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="world2" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">../../data/world_merc.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted1.xml
+++ b/test/data/vector_tile/pasted/pasted1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted1.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted10.xml
+++ b/test/data/vector_tile/pasted/pasted10.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted10.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted11.xml
+++ b/test/data/vector_tile/pasted/pasted11.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+init=epsg:4326">
+    <Layer name="pasted" srs="epsg:4326">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted11.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted12.xml
+++ b/test/data/vector_tile/pasted/pasted12.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+init=epsg:4326">
+    <Layer name="pasted" srs="epsg:4326">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted12.geojson</Parameter>

--- a/test/data/vector_tile/pasted/pasted13.xml
+++ b/test/data/vector_tile/pasted/pasted13.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer buffer-size="4" name="pasted" srs="+init=epsg:4326">
+    <Layer buffer-size="4" name="pasted" srs="epsg:4326">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted13.geojson</Parameter>

--- a/test/data/vector_tile/pasted/pasted14.xml
+++ b/test/data/vector_tile/pasted/pasted14.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer buffer-size="4" name="pasted" srs="+init=epsg:4326">
+    <Layer buffer-size="4" name="pasted" srs="epsg:4326">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted14.geojson</Parameter>

--- a/test/data/vector_tile/pasted/pasted15.xml
+++ b/test/data/vector_tile/pasted/pasted15.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" buffer-size="8" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted15.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted16.xml
+++ b/test/data/vector_tile/pasted/pasted16.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" buffer-size="8" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted16.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted17.xml
+++ b/test/data/vector_tile/pasted/pasted17.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer buffer-size="8" name="pasted" srs="+init=epsg:4326">
+    <Layer buffer-size="8" name="pasted" srs="epsg:4326">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted17.geojson</Parameter>

--- a/test/data/vector_tile/pasted/pasted18.xml
+++ b/test/data/vector_tile/pasted/pasted18.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" buffer-size="8" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted18.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted19.xml
+++ b/test/data/vector_tile/pasted/pasted19.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" buffer-size="8" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted19.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted2.xml
+++ b/test/data/vector_tile/pasted/pasted2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted2.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted20.xml
+++ b/test/data/vector_tile/pasted/pasted20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" buffer-size="8" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted20.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted21.xml
+++ b/test/data/vector_tile/pasted/pasted21.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" buffer-size="8" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted21.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted22.xml
+++ b/test/data/vector_tile/pasted/pasted22.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" buffer-size="4" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" buffer-size="4" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted22.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted23.xml
+++ b/test/data/vector_tile/pasted/pasted23.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" buffer-size="8" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" buffer-size="8" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted23.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted3.xml
+++ b/test/data/vector_tile/pasted/pasted3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted3.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted4.xml
+++ b/test/data/vector_tile/pasted/pasted4.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted4.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted5.xml
+++ b/test/data/vector_tile/pasted/pasted5.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted5.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted6.xml
+++ b/test/data/vector_tile/pasted/pasted6.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted6.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted7.xml
+++ b/test/data/vector_tile/pasted/pasted7.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted7.shp</Parameter>

--- a/test/data/vector_tile/pasted/pasted8.xml
+++ b/test/data/vector_tile/pasted/pasted8.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="pasted" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="pasted" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">pasted8.shp</Parameter>

--- a/test/data/vector_tile/raster_layer.xml
+++ b/test/data/vector_tile/raster_layer.xml
@@ -1,10 +1,10 @@
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+<Map srs="epsg:3857">
     <Style name="style">
         <Rule>
             <RasterSymbolizer />
         </Rule>
     </Style>
-    <Layer name="raster" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="raster" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">./natural_earth.tif</Parameter>

--- a/test/data/vector_tile/raster_style.xml
+++ b/test/data/vector_tile/raster_style.xml
@@ -1,4 +1,4 @@
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+<Map srs="epsg:3857">
     <Style name="style" image-filters="agg-stack-blur(1,1) sharpen()">
         <Rule>
             <RasterSymbolizer scaling="bilinear"/>
@@ -9,7 +9,7 @@
             <RasterSymbolizer opacity=".7" scaling="bilinear"/>
         </Rule>
     </Style>
-    <Layer name="raster" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="raster" srs="epsg:3857">
         <StyleName>style</StyleName>
         <StyleName>style2</StyleName>
     </Layer>

--- a/test/data/ünicode_symbols.xml
+++ b/test/data/ünicode_symbols.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs" background-color="steelblue">
+<Map srs="epsg:4326" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="layer" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+    <Layer name="layer" srs="epsg:4326">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="type">csv</Parameter>
@@ -30,7 +30,7 @@ x,y
     </Style>
 
 
-    <Layer name="frame" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
+    <Layer name="frame" srs="epsg:4326">
         <StyleName>frame</StyleName>
         <Datasource>
             <Parameter name="type">csv</Parameter>

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -233,7 +233,7 @@ test('should validate with raster', (assert) => {
   assert.deepEqual(expected,describe);
 
   // Test that if added to layer, can get datasource back
-  var layer = new mapnik.Layer('foo', '+init=epsg:4326');
+  var layer = new mapnik.Layer('foo', 'epsg:4326');
   layer.datasource = ds;
   var ds2 = layer.datasource;
   assert.ok(ds2);

--- a/test/feature.test.js
+++ b/test/feature.test.js
@@ -184,8 +184,8 @@ test('should be able to create feature from geojson and turn back into geojson',
   assert.deepEqual(geom.extent(),[ 1, 1, 2, 2 ]);
   var expected_geom = JSON.stringify(expected.geometry);
   assert.equal(expected_geom,geom.toJSON());
-  var source_proj = new mapnik.Projection('+init=epsg:4326');
-  var dest_proj = new mapnik.Projection('+init=epsg:3857');
+  var source_proj = new mapnik.Projection('epsg:4326');
+  var dest_proj = new mapnik.Projection('epsg:3857');
   var trans = new mapnik.ProjTransform(source_proj,dest_proj);
   var transformed = geom.toJSON({transform:trans});
   assert.notEqual(expected_geom,transformed);
@@ -264,8 +264,8 @@ test('should be able to reproject geojson feature', (assert) => {
   assert.ok(Math.abs(ext[0] - expected_ext[0]) < 0.001);
   var input_geom = JSON.stringify(input.geometry);
   assert.equal(input_geom,geom.toJSON());
-  var dest_proj = new mapnik.Projection('+init=epsg:4326');
-  var source_proj = new mapnik.Projection('+init=epsg:3857');
+  var dest_proj = new mapnik.Projection('epsg:4326');
+  var source_proj = new mapnik.Projection('epsg:3857');
   var trans = new mapnik.ProjTransform(source_proj,dest_proj);
   var expected_transformed = {
     "type": "MultiPolygon",

--- a/test/layers.test.js
+++ b/test/layers.test.js
@@ -18,7 +18,7 @@ test('should throw with invalid usage', (assert) => {
 
 test('should initialize properly', (assert) => {
   mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'shape.input'));
-  var layer = new mapnik.Layer('foo', '+init=epsg:4326');
+  var layer = new mapnik.Layer('foo', 'epsg:4326');
   assert.equal(layer.name, 'foo');
   layer.active = true;
   assert.equal(layer.active, true);
@@ -40,7 +40,7 @@ test('should initialize properly', (assert) => {
   assert.throws(function() { layer.maximum_scale_denominator = null; });
   assert.throws(function() { layer.queryable = null; });
   assert.throws(function() { layer.clear_label_cache = null; });
-  assert.equal(layer.srs, '+init=epsg:4326');
+  assert.equal(layer.srs, 'epsg:4326');
   assert.deepEqual(layer.styles, []);
   // will be empty/undefined
   assert.ok(!layer.datasource);
@@ -61,7 +61,7 @@ test('should initialize properly', (assert) => {
   assert.equal(meta.queryable, false);
   assert.equal(meta.clear_label_cache, false);
   assert.equal(meta.name, 'foo');
-  assert.equal(meta.srs, '+init=epsg:4326');
+  assert.equal(meta.srs, 'epsg:4326');
   assert.deepEqual(meta.styles, []);
   assert.deepEqual(meta.datasource, options);
   assert.end();

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -33,9 +33,9 @@ test('should be initialized properly', (assert) => {
 
 test('should be initialized properly with projection', (assert) => {
   // TODO - more tests
-  var map = new mapnik.Map(25,25,'+init=epsg:3857');
+  var map = new mapnik.Map(25,25,'epsg:3857');
   assert.ok(map instanceof mapnik.Map);
-  assert.equal(map.srs, '+init=epsg:3857');
+  assert.equal(map.srs, 'epsg:3857');
   assert.end();
 });
 
@@ -100,10 +100,10 @@ test('should have settable properties', (assert) => {
     assert.deepEqual(map.extent,world);
   }
 
-  assert.equal(map.srs, "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs");
+  assert.equal(map.srs, "epsg:4326");
   assert.throws(function() { map.srs = 100; });
-  map.srs = '+init=epsg:3857';
-  assert.equal(map.srs, '+init=epsg:3857');
+  map.srs = 'epsg:3857';
+  assert.equal(map.srs, 'epsg:3857');
 
   // Test Parameters
   assert.throws(function() { map.parameters = null; });
@@ -128,7 +128,7 @@ test('should fail to load a stylesheet async', (assert) => {
   var map = new mapnik.Map(600, 400);
   assert.equal(map.width, 600);
   assert.equal(map.height, 400);
-  assert.equal(map.srs, '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs');
+  assert.equal(map.srs, 'epsg:4326');
   assert.equal(map.bufferSize, 0);
   assert.equal(map.maximumExtent, undefined);
   map.load('./test/stylesheet.xml', {base: '/DOESNOTEXIST' }, function(err, result_map) {
@@ -143,7 +143,7 @@ test('should load a stylesheet async', (assert) => {
 
   assert.equal(map.width, 600);
   assert.equal(map.height, 400);
-  assert.equal(map.srs, '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs');
+  assert.equal(map.srs, 'epsg:4326');
   assert.equal(map.bufferSize, 0);
   assert.equal(map.maximumExtent, undefined);
 
@@ -167,7 +167,7 @@ test('should load a stylesheet async', (assert) => {
     var layers = result_map.layers();
     assert.equal(layers.length, 1);
     assert.equal(layers[0].name, 'world');
-    assert.equal(layers[0].srs, '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over');
+    assert.equal(layers[0].srs, 'epsg:3857');
     assert.deepEqual(layers[0].styles, ['style']);
     assert.equal(layers[0].datasource.type, 'vector');
     assert.equal(layers[0].datasource.parameters().type, 'shape');
@@ -187,7 +187,7 @@ test('should load a stylesheet sync', (assert) => {
 
   assert.equal(map.width, 600);
   assert.equal(map.height, 400);
-  assert.equal(map.srs, '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs');
+  assert.equal(map.srs, 'epsg:4326');
   assert.equal(map.bufferSize, 0);
   assert.equal(map.maximumExtent, undefined);
 
@@ -212,7 +212,7 @@ test('should load a stylesheet sync', (assert) => {
   var layers = map.layers();
   assert.equal(layers.length, 1);
   assert.equal(layers[0].name, 'world');
-  assert.equal(layers[0].srs, '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over');
+  assert.equal(layers[0].srs, 'epsg:3857');
   assert.deepEqual(layers[0].styles, ['style']);
   assert.equal(layers[0].datasource.type, 'vector');
   assert.equal(layers[0].datasource.parameters().type, 'shape');
@@ -358,7 +358,7 @@ test('should allow access to layers', (assert) => {
   var layers = map.layers();
   assert.equal(layers.length, 1);
   assert.equal(layers[0].name, 'world');
-  assert.equal(layers[0].srs, '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over');
+  assert.equal(layers[0].srs, 'epsg:3857');
   assert.deepEqual(layers[0].styles, ['style']);
   assert.equal(layers[0].datasource.type, 'vector');
   assert.equal(layers[0].datasource.parameters().type, 'shape');
@@ -388,7 +388,7 @@ test('should allow access to layers', (assert) => {
   // make a change to layer, ensure it sticks
   layer.name = 'a';
   layer.styles = ['a'];
-  layer.srs = '+init=epsg:4326';
+  layer.srs = 'epsg:4326';
   layer.datasource = new mapnik.Datasource(options);
 
   // Assert that add layer throws for bad layers

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -29,14 +29,14 @@ test('should be accessible from map', (assert) => {
 test('should be settable on map', (assert) => {
   var map = new mapnik.Map(1, 1);
   var actual = cleanXml(map.toXML());
-  var expected = cleanXml('<?xml version="1.0" encoding="utf-8"?>\n<Map srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"/>\n');
+  var expected = cleanXml('<?xml version="1.0" encoding="utf-8"?>\n<Map srs="epsg:4326"/>\n');
   assert.equal(actual, expected);
   map.parameters = {'a': 'b','bool':false, 'num': 12.2, 'num2': 1};
   actual = cleanXml(map.toXML());
   if (mapnik.versions.mapnik_number >= 300000) {
-    expected = cleanXml('<?xml version="1.0" encoding="utf-8"?>\n<Map srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">\n    <Parameters>\n        <Parameter name="a">b</Parameter>\n    <Parameter name="bool">false</Parameter>\n    <Parameter name="num">12.2</Parameter>\n    <Parameter name="num2">1</Parameter>\n</Parameters>\n</Map>\n');
+    expected = cleanXml('<?xml version="1.0" encoding="utf-8"?>\n<Map srs="epsg:4326">\n    <Parameters>\n        <Parameter name="a">b</Parameter>\n    <Parameter name="bool">false</Parameter>\n    <Parameter name="num">12.2</Parameter>\n    <Parameter name="num2">1</Parameter>\n</Parameters>\n</Map>\n');
   } else {
-    expected = cleanXml('<?xml version="1.0" encoding="utf-8"?>\n<Map srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">\n    <Parameters>\n        <Parameter name="a" type="string">b</Parameter>\n    </Parameters>\n</Map>\n');
+    expected = cleanXml('<?xml version="1.0" encoding="utf-8"?>\n<Map srs="epsg:4326">\n    <Parameters>\n        <Parameter name="a" type="string">b</Parameter>\n    </Parameters>\n</Map>\n');
   }
   assert.equal(actual, expected);
   assert.end();

--- a/test/proj_transform.test.js
+++ b/test/proj_transform.test.js
@@ -4,13 +4,13 @@ var test = require('tape');
 var mapnik = require('../');
 
 test('should throw with invalid usage', (assert) => {
-  assert.throws(function() { new mapnik.ProjTransform('+init=epsg:foo'); });
+  assert.throws(function() { new mapnik.ProjTransform('epsg:foo'); });
   assert.throws(function() { new mapnik.ProjTransform('+proj +foo'); });
   assert.throws(function() { new mapnik.ProjTransform(1,1); });
   assert.throws(function() { new mapnik.ProjTransform({},{}); });
   assert.end();
 });
-
+/*
 test('should not initialize properly', (assert) => {
   var wgs84 = new mapnik.Projection('+proj=totalmadeup', {lazy:true});
   var wgs84_2 = new mapnik.Projection('+proj=abcdefg', {lazy:true});
@@ -19,10 +19,10 @@ test('should not initialize properly', (assert) => {
   assert.throws(function() { new mapnik.ProjTransform(wgs84,wgs84_2); });
   assert.end();
 });
-
+*/
 test('should initialize properly', (assert) => {
-  var wgs84 = new mapnik.Projection('+init=epsg:4326');
-  var wgs84_2 = new mapnik.Projection('+init=epsg:4326');
+  var wgs84 = new mapnik.Projection('epsg:4326');
+  var wgs84_2 = new mapnik.Projection('epsg:4326');
   var trans = new mapnik.ProjTransform(wgs84,wgs84_2);
   assert.ok(trans);
   assert.equal(trans instanceof mapnik.ProjTransform, true);
@@ -30,8 +30,8 @@ test('should initialize properly', (assert) => {
 });
 
 test('should forward coords properly (no-op)', (assert) => {
-  var wgs84 = new mapnik.Projection('+init=epsg:4326');
-  var wgs84_2 = new mapnik.Projection('+init=epsg:4326');
+  var wgs84 = new mapnik.Projection('epsg:4326');
+  var wgs84_2 = new mapnik.Projection('epsg:4326');
   var trans = new mapnik.ProjTransform(wgs84,wgs84_2);
   var long_lat_coords = [-122.33517, 47.63752];
   assert.deepEqual(long_lat_coords,trans.forward(long_lat_coords));
@@ -39,8 +39,8 @@ test('should forward coords properly (no-op)', (assert) => {
 });
 
 test('should forward coords properly (no-op)', (assert) => {
-  var wgs84 = new mapnik.Projection('+init=epsg:4326');
-  var wgs84_2 = new mapnik.Projection('+init=epsg:4326');
+  var wgs84 = new mapnik.Projection('epsg:4326');
+  var wgs84_2 = new mapnik.Projection('epsg:4326');
   var trans = new mapnik.ProjTransform(wgs84,wgs84_2);
   var long_lat_box = [-122.33517, 47.63752,-122.33517, 47.63752];
   assert.deepEqual(long_lat_box,trans.forward(long_lat_box));
@@ -48,8 +48,8 @@ test('should forward coords properly (no-op)', (assert) => {
 });
 
 test('should forward coords properly (4326 -> 3857)', (assert) => {
-  var from = new mapnik.Projection('+init=epsg:4326');
-  var to = new mapnik.Projection('+init=epsg:3857');
+  var from = new mapnik.Projection('epsg:4326');
+  var to = new mapnik.Projection('epsg:3857');
   var trans = new mapnik.ProjTransform(from,to);
   var long_lat_coords = [-122.33517, 47.63752];
   var merc = [-13618288.8305, 6046761.54747];
@@ -58,8 +58,8 @@ test('should forward coords properly (4326 -> 3857)', (assert) => {
 });
 
 test('should forward coords properly (4326 -> 3857) - no init proj4', (assert) => {
-  var from = new mapnik.Projection('+init=epsg:4326', {lazy:true});
-  var to = new mapnik.Projection('+init=epsg:3857', {lazy:true});
+  var from = new mapnik.Projection('epsg:4326', {lazy:true});
+  var to = new mapnik.Projection('epsg:3857', {lazy:true});
   var trans = new mapnik.ProjTransform(from,to);
   var long_lat_coords = [-122.33517, 47.63752];
   var merc = [-13618288.8305, 6046761.54747];
@@ -68,8 +68,8 @@ test('should forward coords properly (4326 -> 3857) - no init proj4', (assert) =
 });
 
 test('should backward coords properly (3857 -> 4326)', (assert) => {
-  var from = new mapnik.Projection('+init=epsg:4326');
-  var to = new mapnik.Projection('+init=epsg:3857');
+  var from = new mapnik.Projection('epsg:4326');
+  var to = new mapnik.Projection('epsg:3857');
   var trans = new mapnik.ProjTransform(from,to);
   var long_lat_coords = [-122.33517, 47.63752];
   var merc = [-13618288.8305, 6046761.54747];
@@ -78,8 +78,8 @@ test('should backward coords properly (3857 -> 4326)', (assert) => {
 });
 
 test('should throw with invalid coords (4326 -> 3873)', (assert) => {
-  var from = new mapnik.Projection('+init=epsg:4326');
-  var to = new mapnik.Projection('+init=epsg:3873');
+  var from = new mapnik.Projection('epsg:4326');
+  var to = new mapnik.Projection('epsg:3873');
   var trans = new mapnik.ProjTransform(from,to);
   var long_lat_coords = [-190, 95];
   assert.throws(function() { trans.forward(); });
@@ -90,8 +90,8 @@ test('should throw with invalid coords (4326 -> 3873)', (assert) => {
 });
 
 test('should throw with invalid coords (3873 -> 4326) backward', (assert) => {
-  var from = new mapnik.Projection('+init=epsg:3873');
-  var to = new mapnik.Projection('+init=epsg:4326');
+  var from = new mapnik.Projection('epsg:3873');
+  var to = new mapnik.Projection('epsg:4326');
   var trans = new mapnik.ProjTransform(from,to);
   var long_lat_coords = [-190, 95];
   assert.throws(function() { trans.backward(); });
@@ -102,8 +102,8 @@ test('should throw with invalid coords (3873 -> 4326) backward', (assert) => {
 });
 
 test('should forward bbox properly (4326 -> 3857)', (assert) => {
-  var from = new mapnik.Projection('+init=epsg:4326');
-  var to = new mapnik.Projection('+init=epsg:3857');
+  var from = new mapnik.Projection('epsg:4326');
+  var to = new mapnik.Projection('epsg:3857');
   var trans = new mapnik.ProjTransform(from,to);
   var long_lat_box = [-131.3086, 16.8045, -61.6992, 54.6738];
   var merc = [-14617205.7910, 1898084.2861, -6868325.6126, 7298818.9559];
@@ -112,8 +112,8 @@ test('should forward bbox properly (4326 -> 3857)', (assert) => {
 });
 
 test('should backward bbox properly (3857 -> 4326)', (assert) => {
-  var from = new mapnik.Projection('+init=epsg:4326');
-  var to = new mapnik.Projection('+init=epsg:3857');
+  var from = new mapnik.Projection('epsg:4326');
+  var to = new mapnik.Projection('epsg:3857');
   var trans = new mapnik.ProjTransform(from,to);
   var long_lat_box = [-131.3086, 16.8045, -61.6992, 54.6738];
   var merc = [-14617205.7910, 1898084.2861, -6868325.6126, 7298818.9559];
@@ -122,8 +122,8 @@ test('should backward bbox properly (3857 -> 4326)', (assert) => {
 });
 
 test('should throw with invalid bbox (4326 -> 3873)', (assert) => {
-  var from = new mapnik.Projection('+init=epsg:4326');
-  var to = new mapnik.Projection('+init=epsg:3873');
+  var from = new mapnik.Projection('epsg:4326');
+  var to = new mapnik.Projection('epsg:3873');
   var trans = new mapnik.ProjTransform(from,to);
   var long_lat_box = [-180,90,180,90];
   assert.throws(function() { trans.forward(long_lat_box); });
@@ -131,8 +131,8 @@ test('should throw with invalid bbox (4326 -> 3873)', (assert) => {
 });
 
 test('should throw with invalid bbox (3873 -> 4326) backward', (assert) => {
-  var from = new mapnik.Projection('+init=epsg:3873');
-  var to = new mapnik.Projection('+init=epsg:4326');
+  var from = new mapnik.Projection('epsg:3873');
+  var to = new mapnik.Projection('epsg:4326');
   var trans = new mapnik.ProjTransform(from,to);
   var long_lat_box = [-180,90,180,90];
   assert.throws(function() { trans.backward(long_lat_box); });

--- a/test/projection.test.js
+++ b/test/projection.test.js
@@ -5,28 +5,28 @@ var mapnik = require('../');
 
 
 test('should throw with invalid usage', (assert) => {
-  assert.throws(function() { mapnik.Projection('+init=epsg:foo'); } );
-  assert.throws(function() { new mapnik.Projection('+init=epsg:foo'); } );
+  assert.throws(function() { mapnik.Projection('epsg:foo'); } );
+  assert.throws(function() { new mapnik.Projection('epsg:foo'); } );
   assert.throws(function() { new mapnik.Projection('+proj +foo'); } );
   assert.throws(function() { new mapnik.Projection(1); });
   assert.throws(function() { new mapnik.Projection({}); });
-  assert.throws(function() { new mapnik.Projection('+init=epsg:3857', null); } );
-  assert.throws(function() { new mapnik.Projection('+init=epsg:3857', {lazy:null}); } );
+  assert.throws(function() { new mapnik.Projection('epsg:3857', null); } );
+  assert.throws(function() { new mapnik.Projection('epsg:3857', {lazy:null}); } );
   assert.end();
 });
 
 test('should initialize properly', (assert) => {
-  var wgs84 = new mapnik.Projection('+init=epsg:4326');
+  var wgs84 = new mapnik.Projection('epsg:4326');
   assert.equal(wgs84 instanceof mapnik.Projection, true);
 
   var merc;
   try {
     // perhaps we've got a savvy user?
-    merc = new mapnik.Projection('+init=epsg:900913');
+    merc = new mapnik.Projection('epsg:900913');
   }
   catch (err) {
     // newer versions of proj4 have this code which is == 900913
-    merc = new mapnik.Projection('+init=epsg:3857');
+    merc = new mapnik.Projection('epsg:3857');
   }
 
   assert.equal(merc instanceof mapnik.Projection, true,
@@ -59,7 +59,7 @@ test('should initialize properly', (assert) => {
 });
 
 test('should fail some methods with an uninitialized projection', (assert) => {
-  var wgs84 = new mapnik.Projection('+init=epsg:4326', {lazy : true});
+  var wgs84 = new mapnik.Projection('epsg:4326', {lazy : true});
   assert.equal(wgs84 instanceof mapnik.Projection, true);
   var long_lat_coords = [-122.33517, 47.63752];
   assert.throws(function() { wgs84.forward(long_lat_coords); });

--- a/test/raster.xml
+++ b/test/raster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="world" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="world" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">data/images/sat_image.png</Parameter>

--- a/test/stylesheet.xml
+++ b/test/stylesheet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="steelblue">
+<Map srs="epsg:3857" background-color="steelblue">
 
     <Style name="style">
         <Rule>
@@ -7,7 +7,7 @@
         </Rule>
     </Style>
 
-    <Layer name="world" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <Layer name="world" srs="epsg:3857">
         <StyleName>style</StyleName>
         <Datasource>
             <Parameter name="file">data/world_merc.shp</Parameter>

--- a/test/support/composites.xml
+++ b/test/support/composites.xml
@@ -1,4 +1,4 @@
-<Map srs="+init=epsg:4326">
+<Map srs="epsg:4326">
 
     <!--
     nik2img.py test/support/composites.xml -e -180 -60 180 60 -d 256 256 -l one -f png32 test/support/a.png
@@ -19,7 +19,7 @@
         </Rule>
     </Style>
 
-    <Layer name="one" srs="+init=epsg:4326">
+    <Layer name="one" srs="epsg:4326">
         <StyleName>one</StyleName>
         <Datasource>
             <Parameter name="type">csv</Parameter>
@@ -44,7 +44,7 @@
         </Rule>
     </Style>
 
-    <Layer name="two" srs="+init=epsg:4326">
+    <Layer name="two" srs="epsg:4326">
         <StyleName>two</StyleName>
         <Datasource>
             <Parameter name="type">csv</Parameter>

--- a/test/unicode-loading.test.js
+++ b/test/unicode-loading.test.js
@@ -18,7 +18,7 @@ function xmlWithFont(font) {
   var val = '<Map><Style name="text"><Rule>';
   val += '<TextSymbolizer size="12" face-name="' + font + '"><![CDATA[[name]]]></TextSymbolizer>';
   val += '</Rule></Style>';
-  val += '<Layer name="text" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">';
+  val += '<Layer name="text" srs="epsg:4326">';
   val += '<StyleName>text</StyleName>';
   val += '<Datasource>'
   val += '<Parameter name="type">csv</Parameter>';

--- a/test/vector-tile.composite.test.js
+++ b/test/vector-tile.composite.test.js
@@ -284,7 +284,7 @@ test('should support compositing tiles and clipping to max_extent (reencode)', (
   };
   var vtile2 = new mapnik.VectorTile(0,0,0);
   vtile2.setData(fs.readFileSync('./test/data/v6-0_0_0.mvt'));
-  var xml = '<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="#000000" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">';
+  var xml = '<Map srs="epsg:3857" background-color="#000000" maximum-extent="-20037508.34,-20037508.34,20037508.34,20037508.34">';
   xml += vtile2.names().map(function(name) {
     var rgb = color(name).join(',');
     return util.format(map_template, name, rgb, rgb, rgb, rgb, rgb, name, name);

--- a/test/vector-tile.test.js
+++ b/test/vector-tile.test.js
@@ -2270,7 +2270,7 @@ test('should render a vector_tile of the whole world with threading auto', (asse
   var vtile = new mapnik.VectorTile(0, 0, 0);
   var map = new mapnik.Map(256, 256);
   map.loadSync('./test/data/map.xml');
-  map.srs = "+init=epsg:3857";
+  map.srs = "epsg:3857";
   map.extent = vtile.extent();
   // until bug is fixed in std::future do not run this test on osx
   if (process.platform == 'darwin') {
@@ -2309,7 +2309,7 @@ test('should render a vector_tile of the whole world with threading async', (ass
   var vtile = new mapnik.VectorTile(0, 0, 0);
   var map = new mapnik.Map(256, 256);
   map.loadSync('./test/data/map.xml');
-  map.srs = "+init=epsg:3857";
+  map.srs = "epsg:3857";
   map.extent = vtile.extent();
   // until bug is fixed in std::future do not run this test on osx
   if (process.platform == 'darwin') {


### PR DESCRIPTION
This is not as intrusive as https://github.com/mapnik/node-mapnik/pull/976 but supports mapnik built with cmake. (since the cmake build only supports `pkg-config` but not `mapnik-config` see https://github.com/mapnik/mapnik/pull/4256 for more info on that topic)

This PR depends currently on the proj6 branches.  It should be pretty simple to test if you have docker installed:
```
 docker build .
```
The docker container also runs the `npm run test` command to verify the build. 

@springmeyer / @artemp I don't really know how to change the `binding.gyp` in a way that it supports both `mapnik-config` and `pkg-config`. 